### PR TITLE
[WIP] Renaming, remove re-exports

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,11 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+### Changed
+
+* Rename `paysSelf` and `paysOther` into `paysToSelf` and `paysToOther` for
+  consistency.
+
 ### Removed
 
 * Various re-exports from `Test.Tasty.Plutus.Script.Unit`.

--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -8,6 +8,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * Rename `paysSelf` and `paysOther` into `paysToSelf` and `paysToOther` for
   consistency.
+* Rename `ValidatorTest` to `ScriptTest`.
 
 ### Removed
 

--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,10 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+### Removed
+
+* Various re-exports from `Test.Tasty.Plutus.Script.Unit`.
+
 ## 3.1 -- 2021-10-06
 
 ### Added

--- a/tasty-plutus/src/Test/Tasty/Plutus/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Context.hs
@@ -38,8 +38,8 @@ module Test.Tasty.Plutus.Context (
   paysToWallet,
   paysLovelaceToPubKey,
   paysLovelaceToWallet,
-  paysSelf,
-  paysOther,
+  paysToSelf,
+  paysToOther,
 
   -- ** Spending
   spendsFromPubKey,
@@ -157,30 +157,30 @@ paysToWallet wallet = paysToPubKey (walletPubKeyHash wallet)
 
 {- | Indicate that the script being tested must pay itself the given amount.
 
- @since 1.0
+ @since 4.0
 -}
-paysSelf ::
+paysToSelf ::
   forall (p :: Internal.Purpose) (a :: Type).
   (ToData a) =>
   Value ->
   a ->
   Internal.ContextBuilder p
-paysSelf v dt =
+paysToSelf v dt =
   output . Internal.Output (Internal.OwnType . toBuiltinData $ dt) $ v
 
 {- | Indicate that the script being tested must pay another script the given
  amount.
 
- @since 1.0
+ @since 4.0
 -}
-paysOther ::
+paysToOther ::
   forall (p :: Internal.Purpose) (a :: Type).
   (ToData a) =>
   ValidatorHash ->
   Value ->
   a ->
   Internal.ContextBuilder p
-paysOther hash v dt =
+paysToOther hash v dt =
   output . Internal.Output (Internal.ScriptType hash . toBuiltinData $ dt) $ v
 
 {- | As 'paysToPubKey', but using Lovelace.

--- a/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
@@ -19,37 +19,11 @@
  >    shouldn'tValidate "Invalid data" invalidData validContext
  >    shouldn'tValidate "Everything is bad" invalidData invalidContext
  >    ...
-
- = Note
-
- This re-exports multiple definitions for backwards-compatibility reasons.
- Many of these will disappear on the next major version bump: the only definitions
- that are guaranteed to remain are:
-
- * 'shouldValidate'
- * 'shouldn'tValidate'
 -}
 module Test.Tasty.Plutus.Script.Unit (
-  -- * Validator context types
-  TestData (..),
-  WithScript,
-
-  -- * Wrappers
-  toTestValidator,
-  toTestMintingPolicy,
-
   -- * Testing API
-  withValidator,
-  withMintingPolicy,
   shouldValidate,
   shouldn'tValidate,
-
-  -- * Options
-  Fee (..),
-  TimeRange (..),
-  TestTxId (..),
-  TestCurrencySymbol (..),
-  TestValidatorHash (..),
 ) where
 
 import Control.Monad.Reader (asks)
@@ -106,12 +80,6 @@ import Test.Tasty.Plutus.Options (
   TimeRange (TimeRange),
  )
 import Test.Tasty.Plutus.TestData (TestData (MintingTest, SpendingTest))
-import Test.Tasty.Plutus.WithScript (
-  toTestMintingPolicy,
-  toTestValidator,
-  withMintingPolicy,
-  withValidator,
- )
 import Test.Tasty.Providers (
   IsTest (run, testOptions),
   Result,

--- a/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
@@ -144,21 +144,21 @@ shouldn'tValidate name td cb = case td of
 
 data Outcome = Fail | Pass
 
-data ValidatorTest (p :: Purpose) where
+data ScriptTest (p :: Purpose) where
   Spender ::
     Outcome ->
     TestData 'ForSpending ->
     ContextBuilder 'ForSpending ->
     Validator ->
-    ValidatorTest 'ForSpending
+    ScriptTest 'ForSpending
   Minter ::
     Outcome ->
     TestData 'ForMinting ->
     ContextBuilder 'ForMinting ->
     MintingPolicy ->
-    ValidatorTest 'ForMinting
+    ScriptTest 'ForMinting
 
-instance (Typeable p) => IsTest (ValidatorTest p) where
+instance (Typeable p) => IsTest (ScriptTest p) where
   run opts vt _ = pure $ case vt of
     Spender expected td@(SpendingTest d r v) cb val ->
       let context = compileSpending conf cb d v

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               tasty-plutus
-version:            3.1
+version:            4.0
 extra-source-files: CHANGELOG.md
 
 common lang


### PR DESCRIPTION
This fixes #20 and #22. We also use this opportunity to remove the re-exports from `Unit`.