### PR TITLE
Repair #36 for unit-like interface

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -20,6 +20,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 * Multiple definitions moved to own modules from `Unit`. `Unit` still re-exports
   these temporarily for backwards compatibility.
 * Only one `Internal` module containing everything that needs hiding.
+* `EvaluationError` no longer causes a test abort.
 
 ### Deleted
 

--- a/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
@@ -67,7 +67,11 @@ import Plutus.V1.Ledger.Scripts (
   Datum (Datum),
   MintingPolicy,
   Redeemer (Redeemer),
-  ScriptError,
+  ScriptError (
+    EvaluationError,
+    EvaluationException,
+    MalformedScript
+  ),
   Validator,
   ValidatorHash,
   runMintingPolicyScript,
@@ -199,14 +203,14 @@ instance (Typeable p) => IsTest (ValidatorTest p) where
           d' = Datum . toBuiltinData $ d
           r' = Redeemer . toBuiltinData $ r
        in case runScript context' val d' r' of
-            Left err -> testFailed . formatScriptError $ err
+            Left err -> handleError shouldChat expected conf context td err
             Right (_, logs) -> deliverResult shouldChat expected logs conf context td
     Minter expected td@(MintingTest r) cb mp ->
       let context = compileMinting conf cb
           context' = Context . toBuiltinData $ context
           r' = Redeemer . toBuiltinData $ r
        in case runMintingPolicyScript context' mp r' of
-            Left err -> testFailed . formatScriptError $ err
+            Left err -> handleError shouldChat expected conf context td err
             Right (_, logs) -> deliverResult shouldChat expected logs conf context td
     where
       conf :: TransactionConfig
@@ -240,6 +244,57 @@ instance (Typeable p) => IsTest (ValidatorTest p) where
       , Option @PlutusTracing Proxy
       ]
 
+handleError ::
+  forall (p :: Purpose).
+  PlutusTracing ->
+  Outcome ->
+  TransactionConfig ->
+  ScriptContext ->
+  TestData p ->
+  ScriptError ->
+  Result
+handleError shouldChat expected conf sc td = \case
+  EvaluationError logs msg -> case expected of
+    Pass -> testFailed . unexpectedFailure msg $ logs
+    Fail -> testPassed $ case shouldChat of
+      Always ->
+        renderStyle ourStyle $
+          ""
+            $+$ hang "Logs" 4 (dumpLogs logs)
+      OnlyOnFail -> ""
+  EvaluationException name msg ->
+    testFailed . renderStyle ourStyle $
+      "Unexpected behaviour in script:" <+> text name
+        $+$ hang "Description" 4 (text msg)
+  MalformedScript msg ->
+    testFailed . renderStyle ourStyle $
+      "Script was malformed"
+        $+$ hang "Details" 4 (text msg)
+  where
+    unexpectedFailure :: String -> [Text] -> String
+    unexpectedFailure msg logs =
+      renderStyle ourStyle $
+        "Unexpected failure: " <+> text msg
+          $+$ dumpState logs
+    dumpState :: [Text] -> Doc
+    dumpState logs =
+      ""
+        $+$ hang "Context" 4 (valToDoc . scriptContextToValue $ sc)
+        $+$ hang "Configuration" 4 (ppDoc conf)
+        $+$ hang "Inputs" 4 dumpInputs
+        $+$ hang "Logs" 4 (dumpLogs logs)
+    dumpInputs :: Doc
+    dumpInputs = case td of
+      SpendingTest d r v ->
+        "Datum"
+          $+$ ppDoc d
+          $+$ "Redeemer"
+          $+$ ppDoc r
+          $+$ "Value"
+          $+$ ppDoc v
+      MintingTest r ->
+        "Redeemer" $+$ ppDoc r
+
 deliverResult ::
   forall (p :: Purpose).
   PlutusTracing ->
@@ -265,7 +320,7 @@ deliverResult shouldChat expected logs conf sc td =
       Always ->
         renderStyle ourStyle $
           ""
-            $+$ hang "Logs" 4 dumpLogs
+            $+$ hang "Logs" 4 (dumpLogs logs)
       OnlyOnFail -> ""
     noOutcome :: String
     noOutcome =
@@ -296,7 +351,7 @@ deliverResult shouldChat expected logs conf sc td =
         $+$ hang "Context" 4 (valToDoc . scriptContextToValue $ sc)
         $+$ hang "Configuration" 4 (ppDoc conf)
         $+$ hang "Inputs" 4 dumpInputs
-        $+$ hang "Logs" 4 dumpLogs
+        $+$ hang "Logs" 4 (dumpLogs logs)
     dumpInputs :: Doc
     dumpInputs = case td of
       SpendingTest d r v ->
@@ -308,11 +363,9 @@ deliverResult shouldChat expected logs conf sc td =
           $+$ ppDoc v
       MintingTest r ->
         "Redeemer" $+$ ppDoc r
-    dumpLogs :: Doc
-    dumpLogs = vcat . fmap go . zip [1 ..] $ logs
+
+dumpLogs :: [Text] -> Doc
+dumpLogs = vcat . fmap go . zip [1 ..]
+  where
     go :: (Int, Text) -> Doc
     go (ix, line) = (int ix <> colon) <+> (text . show $ line)
-
-formatScriptError :: ScriptError -> String
-formatScriptError =
-  renderStyle ourStyle . hang "Script execution error:" 4 . ppDoc


### PR DESCRIPTION
Closes #36. Due to the urgency of this issue, the property-test-like interface has not been fixed yet, pending a major refactor.