### PR TITLE
Properly handle script errors for property-based interface

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -10,6 +10,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 * Minting-related `ContextBuilder` functionality is now polymorphic in its
   `Purpose`.
+* Fix a bug where _expected_ script failures reported as test failures in all
+  cases, instead of only when unexpected.
 
 ## 3.1 -- 2021-10-14
 


### PR DESCRIPTION
This is a partial solution to #39 - it avoids the refactoring for now, in favour of some duplication of effort. This is largely because #24 will likely require large API changes (including to this), which could potentially render all the refactoring effort useless.