### PR TITLE
Unify `TracePredicate`'s outputs

### DIFF
--- a/plutus-extra/CHANGELOG.md
+++ b/plutus-extra/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
-## 2.2 -- 2021-10-29
+## 2.2 -- 2021-11-01
 
 ### Added
 
 - `valueAtComputedAddressWithState` function at `Plutus.Contract.Test.Extra`
+
+### Changed
+
+* Unified output of predicate builders that use computed address
 
 ## 2.1 -- 2021-10-22
 

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -354,7 +354,7 @@ showStateIfFailAndReturn ::
   Eff effs Bool
 showStateIfFailAndReturn datas addr result = do
   unless result $ tell @(Doc Void) $ pretty $ CheckedState addr datas
-  return result
+  pure result
 
 {- | Check that the UTxO at a computed address
  and data aquired from contract's writer instance meet some condition.

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -381,8 +381,9 @@ utxoAtComputedAddressWithState contract inst getter check =
       addr
       (check w utxoMap)
 
-{- | Similar to 'utxoAtComputedAddress' but continuation have access
- to a data aquired from contract's writer instance.
+{- | Extract UTxOs at a computed address and call continuation returning
+ Boolean value based the address, UTxOs, and data aquired from contract's writer instance.
+ The address is computed using data acquired from contract's writer instance.
 
    @since 2.1
 -}

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -345,12 +345,6 @@ dataAtComputedAddressWithState contract inst addressGetter check =
           addr
           (any (check w) datums)
 
-{- | Check that the UTxO at a computed address
- and data aquired from contract's writer instance meet some condition.
- The address is computed using data acquired from contract's writer instance.
-
-  @since 2.1
--}
 showStateIfFailAndReturn ::
   forall effs.
   Member (Writer (Doc Void)) effs =>
@@ -362,6 +356,12 @@ showStateIfFailAndReturn datas addr result = do
   unless result $ tell @(Doc Void) $ pretty $ CheckedState addr datas
   return result
 
+{- | Check that the UTxO at a computed address
+ and data aquired from contract's writer instance meet some condition.
+ The address is computed using data acquired from contract's writer instance.
+
+  @since 1.1
+-}
 utxoAtComputedAddressWithState ::
   forall
     (w :: Type)

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -360,7 +360,7 @@ showStateIfFailAndReturn datas addr result = do
  and data aquired from contract's writer instance meet some condition.
  The address is computed using data acquired from contract's writer instance.
 
-  @since 1.1
+  @since 2.1
 -}
 utxoAtComputedAddressWithState ::
   forall

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -262,16 +262,12 @@ valueAtComputedAddressWithState ::
   (w -> Ledger.Value -> Bool) ->
   TracePredicate
 valueAtComputedAddressWithState contract inst addressGetter check =
-  utxoAtComputedAddressWithStateImpl contract inst addressGetter $ \w addr utxoMap -> do
+  utxoAtComputedAddress contract inst addressGetter $ \w addr utxoMap ->
     let value = foldMap (Ledger.txOutValue . Ledger.txOutTxOut) utxoMap
-        result = check w value
-    unless result $
-      tell @(Doc Void)
-        ( "Funds at address" <+> pretty addr <+> "were" <> pretty value
-            <+> "Contract writer data was"
-            <+> pretty w
-        )
-    pure result
+     in showStateIfFailAndReturn
+          [CheckedValue value, CheckedWriter w]
+          addr
+          (check w value)
 
 {- | Check that the datum at a computed address meet some condition.
  The address is computed using data acquired from contract's writer instance.

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -33,7 +33,7 @@ import Data.List (foldl')
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Row (Row)
-import Data.Text.Prettyprint.Doc (Doc, Pretty, colon, indent, line, pretty, viaShow, vsep, (<+>))
+import Data.Text.Prettyprint.Doc (Doc, Pretty, align, colon, indent, pretty, viaShow, vsep, (<+>))
 import Data.Void (Void)
 import Prelude
 
@@ -171,6 +171,36 @@ walletFundsChangeWithAccumStateImpl exact contract inst wallet toDlt =
                  ]
       pure result
 
+data CheckedState = CheckedState
+  { checkedAddress :: Ledger.Address
+  , checkedData :: [CheckedData]
+  }
+
+data CheckedData where
+  CheckedDatas :: UtxoMap -> CheckedData
+  CheckedValue :: Ledger.Value -> CheckedData
+  CheckedUtxos :: UtxoMap -> CheckedData
+  CheckedWriter :: forall w. Pretty w => w -> CheckedData
+
+instance Pretty CheckedState where
+  pretty (CheckedState address datas) =
+    "At the address" <+> pretty address <+> ":"
+      <+> align (vsep $ map pretty datas)
+
+instance Pretty CheckedData where
+  pretty (CheckedDatas utxos) =
+    "Data was"
+      <+> foldMap (foldMap pretty . Ledger.txData . Ledger.txOutTxTx) utxos
+  pretty (CheckedValue value) =
+    "Funds was"
+      <+> pretty value
+  pretty (CheckedUtxos utxos) =
+    "UTxO was"
+      <+> foldMap viaShow utxos
+  pretty (CheckedWriter w) =
+    "Contract writer data was"
+      <+> pretty w
+
 {- | Check that the funds at a computed address meet some condition.
  The address is computed using data acquired from contract's writer instance.
 
@@ -197,12 +227,12 @@ valueAtComputedAddress ::
   (Ledger.Value -> Bool) ->
   TracePredicate
 valueAtComputedAddress contract inst addressGetter check =
-  utxoAtComputedAddress contract inst addressGetter $ \_ addr utxoMap -> do
+  utxoAtComputedAddress contract inst addressGetter $ \_ addr utxoMap ->
     let value = foldMap (Ledger.txOutValue . Ledger.txOutTxOut) utxoMap
-        result = check value
-    unless result $
-      tell @(Doc Void) ("Funds at address" <+> pretty addr <+> "were" <> pretty value)
-    pure result
+     in showStateIfFailAndReturn
+          [CheckedValue value]
+          addr
+          (check value)
 
 {- | Check that the funds at a computed address
  and data aquired from contract's writer instance meet some condition.
@@ -273,13 +303,10 @@ dataAtComputedAddress ::
 dataAtComputedAddress contract inst addressGetter check =
   utxoAtComputedAddress contract inst addressGetter $ \_ addr utxoMap ->
     let datums = mapMaybe (uncurry $ getTxOutDatum @datum) $ Map.toList utxoMap
-        result = any check datums
-    unless result $
-      tell @(Doc Void)
-        ( "Data at address" <+> pretty addr <+> "was"
-            <+> foldMap (foldMap pretty . Ledger.txData . Ledger.txOutTxTx) utxoMap
-        )
-    pure result
+     in showStateIfFailAndReturn
+          [CheckedDatas utxoMap]
+          addr
+          (any check datums)
 
 {- | Check that the datum at a computed address
  and data aquired from contract's writer instance meet some condition.
@@ -313,6 +340,9 @@ dataAtComputedAddressWithState ::
 dataAtComputedAddressWithState contract inst addressGetter check =
   utxoAtComputedAddress contract inst addressGetter $ \w addr utxoMap ->
     let datums = mapMaybe (uncurry $ getTxOutDatum @datum) $ Map.toList utxoMap
+     in showStateIfFailAndReturn
+          [CheckedDatas utxoMap, CheckedWriter w]
+          addr
           (any (check w) datums)
 
 {- | Check that the UTxO at a computed address
@@ -321,6 +351,17 @@ dataAtComputedAddressWithState contract inst addressGetter check =
 
   @since 2.1
 -}
+showStateIfFailAndReturn ::
+  forall effs.
+  Member (Writer (Doc Void)) effs =>
+  [CheckedData] ->
+  Ledger.Address ->
+  Bool ->
+  Eff effs Bool
+showStateIfFailAndReturn datas addr result = do
+  unless result $ tell @(Doc Void) $ pretty $ CheckedState addr datas
+  return result
+
 utxoAtComputedAddressWithState ::
   forall
     (w :: Type)
@@ -339,6 +380,10 @@ utxoAtComputedAddressWithState ::
   TracePredicate
 utxoAtComputedAddressWithState contract inst getter check =
   utxoAtComputedAddress contract inst getter $ \w addr utxoMap ->
+    showStateIfFailAndReturn
+      [CheckedUtxos utxoMap, CheckedWriter w]
+      addr
+      (check w utxoMap)
 
 {- | Similar to 'utxoAtComputedAddress' but continuation have access
  to a data aquired from contract's writer instance.

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -197,7 +197,7 @@ valueAtComputedAddress ::
   (Ledger.Value -> Bool) ->
   TracePredicate
 valueAtComputedAddress contract inst addressGetter check =
-  utxoAtComputedAddress contract inst addressGetter $ \addr utxoMap -> do
+  utxoAtComputedAddress contract inst addressGetter $ \_ addr utxoMap -> do
     let value = foldMap (Ledger.txOutValue . Ledger.txOutTxOut) utxoMap
         result = check value
     unless result $
@@ -271,7 +271,7 @@ dataAtComputedAddress ::
   (datum -> Bool) ->
   TracePredicate
 dataAtComputedAddress contract inst addressGetter check =
-  utxoAtComputedAddress contract inst addressGetter $ \addr utxoMap -> do
+  utxoAtComputedAddress contract inst addressGetter $ \_ addr utxoMap ->
     let datums = mapMaybe (uncurry $ getTxOutDatum @datum) $ Map.toList utxoMap
         result = any check datums
     unless result $
@@ -311,50 +311,9 @@ dataAtComputedAddressWithState ::
   (w -> datum -> Bool) ->
   TracePredicate
 dataAtComputedAddressWithState contract inst addressGetter check =
-  utxoAtComputedAddressWithStateImpl contract inst addressGetter $ \w addr utxoMap -> do
+  utxoAtComputedAddress contract inst addressGetter $ \w addr utxoMap ->
     let datums = mapMaybe (uncurry $ getTxOutDatum @datum) $ Map.toList utxoMap
-        result = any (check w) datums :: Bool
-    unless result $
-      tell @(Doc Void)
-        ( "Data at address" <+> pretty addr <+> "was"
-            <+> foldMap (foldMap pretty . Ledger.txData . Ledger.txOutTxTx) utxoMap
-            <> line
-            <> "Contract writer data was"
-            <+> pretty w
-        )
-    pure result
-
-{- | Extract UTxOs at a computed address and call continuation returning
- Boolean value based on both the address and UTxOs.
- The address is computed using data acquired from contract's writer instance.
-
-  @since 1.1
--}
-utxoAtComputedAddress ::
-  forall
-    (effs :: [Type -> Type])
-    (w :: Type)
-    (s :: Row Type)
-    (e :: Type)
-    (a :: Type)
-    (contract :: Type -> Row Type -> Type -> Type -> Type).
-  ( Member (Error Folds.EmulatorFoldErr) effs
-  , Member (Writer (Doc Void)) effs
-  , Monoid w
-  , IsContract contract
-  ) =>
-  -- | The 'IsContract' code
-  contract w s e a ->
-  -- | The 'ContractInstanceTag', acquired inside the
-  -- 'Plutus.Trace.Emulator.EmulatorTrace'
-  ContractInstanceTag ->
-  -- | The function computing 'Ledger.Address'
-  (w -> Maybe Ledger.Address) ->
-  -- | The continuation function acting as a predicate
-  (Ledger.Address -> UtxoMap -> Eff effs Bool) ->
-  Folds.EmulatorEventFoldM effs Bool
-utxoAtComputedAddress contract inst addressGetter cont =
-  utxoAtComputedAddressWithStateImpl contract inst addressGetter (const cont)
+          (any (check w) datums)
 
 {- | Check that the UTxO at a computed address
  and data aquired from contract's writer instance meet some condition.
@@ -379,25 +338,14 @@ utxoAtComputedAddressWithState ::
   (w -> UtxoMap -> Bool) ->
   TracePredicate
 utxoAtComputedAddressWithState contract inst getter check =
-  utxoAtComputedAddressWithStateImpl contract inst getter $ \w addr utxoMap ->
-    let result = check w utxoMap
-     in do
-          unless result $
-            tell @(Doc Void)
-              ( "UTxO at address" <+> pretty addr <+> "was"
-                  <+> foldMap viaShow utxoMap
-                  <> line
-                  <> "Contract writer data was"
-                  <+> pretty w
-              )
-          pure result
+  utxoAtComputedAddress contract inst getter $ \w addr utxoMap ->
 
 {- | Similar to 'utxoAtComputedAddress' but continuation have access
  to a data aquired from contract's writer instance.
 
    @since 2.1
 -}
-utxoAtComputedAddressWithStateImpl ::
+utxoAtComputedAddress ::
   forall
     (effs :: [Type -> Type])
     (w :: Type)
@@ -420,7 +368,7 @@ utxoAtComputedAddressWithStateImpl ::
   -- | The continuation function acting as a predicate
   (w -> Ledger.Address -> UtxoMap -> Eff effs Bool) ->
   Folds.EmulatorEventFoldM effs Bool
-utxoAtComputedAddressWithStateImpl contract inst addressGetter cont =
+utxoAtComputedAddress contract inst addressGetter cont =
   flip
     postMapM
     ( (,)


### PR DESCRIPTION
Closes #55 
Instead of corrupted #56 
Just rebased changes on `staging` and resolved conflicts.