### PR TITLE
plutus-laws

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ packages:
   ./plutus-pretty/plutus-pretty.cabal
   ./plutus-numeric/plutus-numeric.cabal
   ./plutus-golden/plutus-golden.cabal
+  ./plutus-laws/plutus-laws.cabal
 
 -- Additional stuff we need
 

--- a/plutus-laws/CHANGELOG.md
+++ b/plutus-laws/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Revision history for `plutus-golden`
+
+This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
+
+## Unreleased
+
+## 1.0 -- 2021-10-19
+
+* Initial release.

--- a/plutus-laws/CHANGELOG.md
+++ b/plutus-laws/CHANGELOG.md
@@ -4,6 +4,6 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
-## 1.0 -- 2021-10-19
+## 1.0 -- 2021-11-03
 
 * Initial release.

--- a/plutus-laws/Makefile
+++ b/plutus-laws/Makefile
@@ -1,0 +1,120 @@
+# The plutus-pab commands, contracts and hoogle environment
+# are made availible by the nix shell defined in shell.nix.
+# In most cases you should execute Make after entering nix-shell.
+
+SHELL := /usr/bin/env bash
+
+.PHONY: hoogle build test watch ghci readme_contents \
+	format lint refactor requires_nix_shell
+
+usage:
+	@echo "usage: make <command> [OPTIONS]"
+	@echo
+	@echo "Available options:"
+	@echo "  FLAGS   -- Additional options passed to --ghc-options"
+	@echo
+	@echo "Available commands:"
+	@echo "  hoogle              -- Start local hoogle"
+	@echo "  build               -- Run cabal v2-build"
+	@echo "  watch               -- Track files and run 'make build' on change"
+	@echo "  test                -- Run cabal v2-test"
+	@echo "  costing             -- Run cost-estimation benchmark"
+	@echo "  coverage            -- Generate a coverage report of the tests"
+	@echo "  ghci                -- Run stack ghci"
+	@echo "  format              -- Apply source code formatting with fourmolu"
+	@echo "  format_check        -- Check source code formatting without making changes"
+	@echo "  cabalfmt            -- Apply cabal formatting with cabal-fmt"
+	@echo "  cabalfmt_check      -- Check cabal files for formatting errors without making changes"
+	@echo "  nixfmt              -- Apply nix formatting with nixfmt"
+	@echo "  nixfmt_check        -- Check nix files for format errors"
+	@echo "  lint                -- Check the sources with hlint"
+	@echo "  refactor            -- Automatically apply hlint refactors, with prompt
+	@echo "  readme_contents     -- Add table of contents to README"
+	@echo "  update_plutus       -- Update plutus version with niv"
+
+hoogle: requires_nix_shell
+	hoogle server --local
+
+STACK_EXE_PATH = $(shell stack $(STACK_FLAGS) path --local-install-root)/bin
+
+ifdef FLAGS
+GHC_FLAGS = --ghc-options "$(FLAGS)"
+endif
+
+build: requires_nix_shell plutus-golden.cabal
+	cabal v2-build $(GHC_FLAGS)
+
+watch: requires_nix_shell plutus-golden.cabal
+	while sleep 1; do find plutus-extra.cabal src test | entr -cd make build; done
+
+test: requires_nix_shell plutus-golden.cabal
+	cabal v2-test
+
+ghci: requires_nix_shell plutus-golden.cabal
+	cabal v2-repl $(GHC_FLAGS)
+
+coverage: plutus-golden.cabal
+	nix-build --arg doCoverage true -A projectCoverageReport
+
+# Source dirs to run fourmolu on
+FORMAT_SOURCES := $(shell find -name '*.hs' -not -path './dist-*/*')
+
+# Extensions we need to tell fourmolu about
+FORMAT_EXTENSIONS := -o -XTemplateHaskell -o -XTypeApplications -o -XImportQualifiedPost -o -XPatternSynonyms -o -fplugin=RecordDotPreprocessor
+
+# Run fourmolu formatter
+format: requires_nix_shell
+	fourmolu --mode inplace --check-idempotence $(FORMAT_EXTENSIONS) $(FORMAT_SOURCES)
+
+# Check formatting (without making changes)
+format_check: requires_nix_shell
+	fourmolu --mode check --check-idempotence $(FORMAT_EXTENSIONS) $(FORMAT_SOURCES)
+
+CABAL_SOURCES := $(shell git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.cabal' )
+
+cabalfmt: requires_nix_shell
+	cabal-fmt --inplace $(CABAL_SOURCES)
+
+cabalfmt_check: requires_nix_shell
+	cabal-fmt --check $(CABAL_SOURCES)
+
+# Nix files to format
+NIX_SOURCES := $(shell git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.nix' )
+
+nixfmt: requires_nix_shell
+	nixfmt $(NIX_SOURCES)
+
+nixfmt_check: requires_nix_shell
+	nixfmt --check $(NIX_SOURCES)
+
+# Check with hlint, currently I couldn't get --refactor to work
+lint: requires_nix_shell
+	hlint $(FORMAT_SOURCES)
+
+# Apply automatic hlint refactors, with prompt
+refactor: requires_nix_shell
+	for src in $(FORMAT_SOURCES) ; do hlint --refactor --refactor-options='-i -s' $$src ; done
+
+readme_contents:
+	echo "this command is not nix-ified, you may receive an error from npx"
+	npx markdown-toc ./README.md --no-firsth1
+
+# Target to use as dependency to fail if not inside nix-shell
+requires_nix_shell:
+	@ [ -v IN_NIX_SHELL ] || echo "The $(MAKECMDGOALS) target must be run from inside nix-shell"
+	@ [ -v IN_NIX_SHELL ] || (echo "    run 'nix-shell --pure' first" && false)
+
+
+PLUTUS_BRANCH = $(shell jq '.plutus.branch' ./nix/sources.json )
+PLUTUS_REPO = $(shell jq '.plutus.owner + "/" + .plutus.repo' ./nix/sources.json )
+PLUTUS_REV = $(shell jq '.plutus.rev' ./nix/sources.json )
+PLUTUS_SHA256 = $(shell jq '.plutus.sha256' ./nix/sources.json )
+
+update_plutus:
+	@echo "Updating plutus version to latest commit at $(PLUTUS_REPO) $(PLUTUS_BRANCH)"
+	niv update plutus
+	@echo "Latest commit: $(PLUTUS_REV)"
+	@echo "Sha256: $(PLUTUS_SHA256)"
+	@echo "Make sure to update the plutus rev in cabal.project with:"
+	@echo "    commit: $(PLUTUS_REV)"
+	@echo "This may require further resolution of dependency versions."

--- a/plutus-laws/README.md
+++ b/plutus-laws/README.md
@@ -1,0 +1,72 @@
+# `plutus-golden`
+
+## What is this?
+
+A framework for testing serialized representation stability using [golden
+testing](https://ro-che.info/articles/2017-12-04-golden-tests). This focuses on
+type classes used for serialization for Plutus projects.
+
+## What can this do?
+
+Currently, we can perform golden testing of the following serializing type
+classes:
+
+* `ToJSON` from `aeson`
+* `ToData` from Plutus
+* `ToSchema` from `openapi3`
+
+For the first two, we support either using an `Arbitrary` instance for
+generating samples, or, if you prefer, you can supply an explicin `Gen` instead.
+
+## What are the goals of this project?
+
+### Convenience
+
+Golden tests can be a bit awkward to set up, as most frameworks for it are
+general and unopinionated to the point of uselessness. This forces you to do a
+lot of manual plumbing and setup, even if most of this generality is not needed.
+`plutus-golden`, due to its narrower focus, aims to avoid _all_ of this - just
+specify what types you want tested, and what type classes to test, and you're
+all set.
+
+This is partly what drives the decision to piggy-back off of `Arbitrary`; due to
+Plutus' support for QuickCheck, it's likely you'll already have such instances
+lying around, especially if you also want to do property testing.
+
+### Good failure reporting
+
+Knowing that a test failed is often far less useful than knowing _why_ it
+failed. This is true of golden testing especially, as you need to figure out
+what exactly changed in the representation. To this end, we aim to give focused
+and useful information about what we expected to see, versus what we actually
+saw, and present it as readably as the type class being checked allows.
+
+This also extends to the format used for sample files: we use JSON throughout,
+as this aids human-readability and manual inspection.
+
+### Integration with `tasty`
+
+The `tasty` test framework supports a range of test types, is extensible,
+scriptable, and provides a lot of solutions to 'boilerplate' around testing.
+`plutus-golden` aims to be a 'good citizen' of the `tasty` universe as much as
+possible, allowing integration between itself and other uses of `tasty` without
+issue.
+
+## How can I use this?
+
+```haskell
+> {-# LANGUAGE TypeApplications #-}
+>
+> import Test.Tasty (testGroup)
+> import Test.Tasty.Plutus.Golden (goldenJSON, goldenDataWith, goldenToSchema)
+> 
+> myGoldenTests :: TestTree
+> myGoldenTests = testGroup "Golden tests" [
+>   goldenJSON @MyType,
+>   goldenDataWith myGenerator @MyOtherType,
+>   goldenToSchema @MyType,
+>   ...
+
+## What can I do with this?
+
+The code is licensed under Apache 2.0; check the LICENSE.md file for details.

--- a/plutus-laws/plutus-laws.cabal
+++ b/plutus-laws/plutus-laws.cabal
@@ -1,0 +1,62 @@
+cabal-version:      3.0
+name:               plutus-laws
+version:            1.0
+extra-source-files: CHANGELOG.md
+
+common lang
+  default-language:   Haskell2010
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    ConstraintKinds
+    DataKinds
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    DerivingVia
+    DuplicateRecordFields
+    EmptyCase
+    FlexibleContexts
+    FlexibleInstances
+    GADTs
+    GeneralizedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NumericUnderscores
+    OverloadedStrings
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeOperators
+    TypeSynonymInstances
+    UndecidableInstances
+
+  build-depends:      base ^>=4.14
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-uni-patterns -Wredundant-constraints
+    -Wmissing-export-lists -Werror -Wincomplete-record-updates
+    -Wmissing-deriving-strategies
+
+library
+  import:          lang
+  exposed-modules: Test.Tasty.Plutus.Laws
+  build-depends:
+    , aeson             ^>=1.5.6.0
+    , aeson-pretty      ^>=0.8.8
+    , bytestring        ^>=0.10.12.0
+    , plutus-tx
+    , pretty            ^>=1.1.3.6
+    , pretty-show       ^>=1.10
+    , QuickCheck        ^>=2.14.2
+    , tagged            ^>=0.8.6.1
+    , tasty             ^>=1.4.1
+    , tasty-quickcheck  ^>=0.10.1.2
+    , text              ^>=1.2.4.1
+
+  hs-source-dirs:  src

--- a/plutus-laws/plutus-laws.cabal
+++ b/plutus-laws/plutus-laws.cabal
@@ -45,7 +45,10 @@ common lang
 
 library
   import:          lang
-  exposed-modules: Test.Tasty.Plutus.Laws
+  exposed-modules:
+    Test.Tasty.Plutus.Arbitrary
+    Test.Tasty.Plutus.Laws
+
   build-depends:
     , aeson             ^>=1.5.6.0
     , aeson-pretty      ^>=0.8.8

--- a/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Test.Tasty.Plutus.Arbitrary (
+  Pair (..),
+  Triple (..),
+  Entangled (Entangled, Disentangled),
+  Entangled3 (Entangled3, Disentangled3),
+) where
+
+import Data.Kind (Type)
+import Test.QuickCheck.Arbitrary (
+  Arbitrary1 (liftArbitrary, liftShrink),
+  arbitrary,
+ )
+
+-- | @since 1.0
+data Pair (a :: Type) = Pair a a
+  deriving stock
+    ( -- | @since 1.0
+      Functor
+    , -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+instance Arbitrary1 Pair where
+  liftArbitrary gen = Pair <$> gen <*> gen
+  liftShrink shr (Pair x y) = Pair <$> shr x <*> shr y
+
+-- | @since 1.0
+data Triple (a :: Type) = Triple a a a
+  deriving stock
+    ( -- | @since 1.0
+      Functor
+    , -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+instance Arbitrary1 Triple where
+  liftArbitrary gen = Triple <$> gen <*> gen <*> gen
+  liftShrink shr (Triple x y z) =
+    Triple <$> shr x <*> shr y <*> shr z
+
+-- | @since 1.0
+data Entangled (a :: Type)
+  = Same a
+  | PossiblyDifferent a a
+  deriving stock
+    ( -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+pattern Entangled :: a -> a -> Entangled a
+pattern Entangled x y <- (delta -> Just (x, y))
+
+-- | @since 1.0
+pattern Disentangled :: a -> a -> Entangled a
+pattern Disentangled x y <- PossiblyDifferent x y
+
+{-# COMPLETE Entangled, Disentangled #-}
+
+-- | @since 1.0
+instance Arbitrary1 Entangled where
+  liftArbitrary gen = do
+    b <- arbitrary
+    x <- gen
+    if b
+      then pure . Same $ x
+      else PossiblyDifferent x <$> gen
+  liftShrink shr = \case
+    Same x -> Same <$> shr x
+    PossiblyDifferent x y -> PossiblyDifferent <$> shr x <*> shr y
+
+-- | @since 1.0
+data Entangled3 (a :: Type)
+  = Same3 a
+  | PossiblyDifferent3 a a a
+  deriving stock
+    ( -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+pattern Entangled3 :: a -> a -> a -> Entangled3 a
+pattern Entangled3 x y z <- (delta3 -> Just (x, y, z))
+
+-- | @since 1.0
+pattern Disentangled3 :: a -> a -> a -> Entangled3 a
+pattern Disentangled3 x y z = PossiblyDifferent3 x y z
+
+{-# COMPLETE Entangled3, Disentangled3 #-}
+
+-- | @since 1.0
+instance Arbitrary1 Entangled3 where
+  liftArbitrary gen = do
+    b <- arbitrary
+    x <- gen
+    if b
+      then pure . Same3 $ x
+      else PossiblyDifferent3 x <$> gen <*> gen
+  liftShrink shr = \case
+    Same3 x -> Same3 <$> shr x
+    PossiblyDifferent3 x y z ->
+      PossiblyDifferent3 <$> shr x <*> shr y <*> shr z
+
+-- Helpers
+
+-- Helper for the view pattern on Entangled
+delta ::
+  forall (a :: Type).
+  Entangled a ->
+  Maybe (a, a)
+delta = \case
+  Same x -> Just (x, x)
+  PossiblyDifferent _ _ -> Nothing
+
+-- Helper for the view pattern on Entangled3
+delta3 ::
+  forall (a :: Type).
+  Entangled3 a ->
+  Maybe (a, a, a)
+delta3 = \case
+  Same3 x -> Just (x, x, x)
+  PossiblyDifferent3 {} -> Nothing

--- a/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
@@ -1,6 +1,16 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 
+{- |
+ Module: Test.Tasty.Plutus.Arbitrary
+ Copyright: (C) MLabs 2021
+ License: Apache 2.0
+ Maintainer: Koz Ross <koz@mlabs.city>
+ Portability: GHC only
+ Stability: Experimental
+
+ A collection of helper types for defining 'Arbitrary' instances.
+-}
 module Test.Tasty.Plutus.Arbitrary (
   Pair (..),
   Triple (..),
@@ -14,7 +24,13 @@ import Test.QuickCheck.Arbitrary (
   arbitrary,
  )
 
--- | @since 1.0
+{- | A single-type tuple. Its 'Arbitrary1' instance makes it convenient to
+ generate pairs of the same type with an explicit generator:
+
+ > aPair :: Pair a <- liftArbitrary gen
+
+ @since 1.0
+-}
 data Pair (a :: Type) = Pair a a
   deriving stock
     ( -- | @since 1.0
@@ -28,7 +44,13 @@ instance Arbitrary1 Pair where
   liftArbitrary gen = Pair <$> gen <*> gen
   liftShrink shr (Pair x y) = Pair <$> shr x <*> shr y
 
--- | @since 1.0
+{- | A single-type 3-tuple. Its 'Arbitrary1' instance makes it convenient to
+ generate pairs of the same type with an explicit generator:
+
+ > aTriple :: Triple a <- liftArbitrary gen
+
+ @since 1.0
+-}
 data Triple (a :: Type) = Triple a a a
   deriving stock
     ( -- | @since 1.0
@@ -43,7 +65,37 @@ instance Arbitrary1 Triple where
   liftShrink shr (Triple x y z) =
     Triple <$> shr x <*> shr y <*> shr z
 
--- | @since 1.0
+{- | 'Entangled' is like 'Pair', but comes in two flavours; either it contains
+ two independently-generated @a@s, or two copies of the /same/ @a@.
+
+ This is mostly designed to address issues of coverage, such as those that
+ might arise from testing a symmetry law for some type class method @foo@
+ (namely, \'if @x `foo` y@, then @y `foo` x@\'). Writing a property test for
+ such a method naively is unlikely to be useful, especially if the type being
+ tested over has large (or infinite) cardinality, as the precondition will be
+ false with high probability. This creates coverage issues.
+
+ This type ensures that we generate enough cases to test the precondition in
+ such situations being true /and/ false, and that both occur roughly as often
+ as each other. The type is designed carefully in that you /cannot/ manually
+ construct an 'Entangled' - you can only generate one (using 'liftArbitrary',
+ for example) or pattern match on it.
+
+ = Important notes
+
+ Using this type requires an assumption of reflexivity in whatever method or
+ methods you are seeking to test (namely, identical things should behave
+ identically). This is typical for pure code (in fact, it is required), but
+ when effects come into play, this may fail. We cannot check for this in
+ general; take care that you do.
+
+ Additionally, if the cardinality of the type over which tests are being run
+ is both finite and small, 'Entangled' will make coverage /worse/, as it will
+ skew the cases towards pairs that match over pairs which don't. Ensure that
+ you don't have such a situation before you use this.
+
+ @since 1.0
+-}
 data Entangled (a :: Type)
   = Same a
   | PossiblyDifferent a a
@@ -52,11 +104,28 @@ data Entangled (a :: Type)
       Show
     )
 
--- | @since 1.0
+{- | You can use this just like a data constructor, but /only/ for pattern
+ matching. If we match, we know that the two values are, in fact, the same
+ value.
+
+ > case ent of
+ >    Entangled x y -> ... -- we know that x and y are the same thing
+
+ @since 1.0
+-}
 pattern Entangled :: a -> a -> Entangled a
 pattern Entangled x y <- (delta -> Just (x, y))
 
--- | @since 1.0
+{- | You can use this just like a data constructor, but /only/ for pattern
+ matching. If we match, we know that the two values were generated
+ independently; they /could/ still be the same, but we don't necessarily know
+ that.
+
+ > case ent of
+ >    Disentangled x y -> ... -- x and y might not be the same
+
+ @since 1.0
+-}
 pattern Disentangled :: a -> a -> Entangled a
 pattern Disentangled x y <- PossiblyDifferent x y
 
@@ -74,7 +143,14 @@ instance Arbitrary1 Entangled where
     Same x -> Same <$> shr x
     PossiblyDifferent x y -> PossiblyDifferent <$> shr x <*> shr y
 
--- | @since 1.0
+{- | Similar to 'Entangled', but for three values instead of two.
+
+ = Note
+
+ All caveats on the use of 'Entangled' also apply here.
+
+ @since 1.0
+-}
 data Entangled3 (a :: Type)
   = Same3 a
   | PossiblyDifferent3 a a a
@@ -83,11 +159,28 @@ data Entangled3 (a :: Type)
       Show
     )
 
--- | @since 1.0
+{- | You can use this just like a data constructor, but /only/ for pattern
+ matching. If we match, we know that the three values are, in fact, the same
+ value.
+
+ > case ent3 of
+ >    Entangled3 x y z -> ... -- we know that x, y, z are all the same thing
+
+ @since 1.0
+-}
 pattern Entangled3 :: a -> a -> a -> Entangled3 a
 pattern Entangled3 x y z <- (delta3 -> Just (x, y, z))
 
--- | @since 1.0
+{- | You can use this just like a data constructor, but /only/ for pattern
+ matching. If we match, we know that the three values were generated
+ independently; some, or all, of them /could/ be the same, but we don't
+ necessarily know that.
+
+ > case ent3 of
+ >    Disentangled3 x y z -> ... -- x, y and/or z might not be the same
+
+ @since 1.0
+-}
 pattern Disentangled3 :: a -> a -> a -> Entangled3 a
 pattern Disentangled3 x y z = PossiblyDifferent3 x y z
 

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Test.Tasty.Plutus.Laws (
   -- * Test API
@@ -67,6 +65,12 @@ import Test.QuickCheck.Arbitrary (
  )
 import Test.QuickCheck.Gen (Gen)
 import Test.Tasty (TestTree)
+import Test.Tasty.Plutus.Arbitrary (
+  Entangled (Disentangled, Entangled),
+  Entangled3 (Disentangled3, Entangled3),
+  Pair (Pair),
+  Triple (Triple),
+ )
 import Test.Tasty.QuickCheck (testProperties)
 import Text.PrettyPrint (
   Doc,
@@ -538,108 +542,7 @@ plutusMonoidLawsWith gen shr =
     rightId :: a -> Property
     rightId x = PlutusTx.mempty PlutusTx.<> x === x
 
--- | @since 1.0
-data Pair (a :: Type) = Pair a a
-  deriving stock
-    ( -- | @since 1.0
-      Functor
-    , -- | @since 1.0
-      Show
-    )
-
--- | @since 1.0
-instance Arbitrary1 Pair where
-  liftArbitrary gen = Pair <$> gen <*> gen
-  liftShrink shr (Pair x y) = Pair <$> shr x <*> shr y
-
--- | @since 1.0
-data Triple (a :: Type) = Triple a a a
-  deriving stock
-    ( -- | @since 1.0
-      Functor
-    , -- | @since 1.0
-      Show
-    )
-
--- | @since 1.0
-instance Arbitrary1 Triple where
-  liftArbitrary gen = Triple <$> gen <*> gen <*> gen
-  liftShrink shr (Triple x y z) =
-    Triple <$> shr x <*> shr y <*> shr z
-
--- | @since 1.0
-data Entangled (a :: Type)
-  = Same a
-  | PossiblyDifferent a a
-  deriving stock
-    ( -- | @since 1.0
-      Show
-    )
-
--- | @since 1.0
-pattern Entangled :: a -> a -> Entangled a
-pattern Entangled x y <- (delta -> Just (x, y))
-
--- | @since 1.0
-pattern Disentangled :: a -> a -> Entangled a
-pattern Disentangled x y <- PossiblyDifferent x y
-
-{-# COMPLETE Entangled, Disentangled #-}
-
--- | @since 1.0
-instance Arbitrary1 Entangled where
-  liftArbitrary gen = do
-    b <- arbitrary
-    x <- gen
-    if b
-      then pure . Same $ x
-      else PossiblyDifferent x <$> gen
-  liftShrink shr = \case
-    Same x -> Same <$> shr x
-    PossiblyDifferent x y -> PossiblyDifferent <$> shr x <*> shr y
-
--- | @since 1.0
-data Entangled3 (a :: Type)
-  = Same3 a
-  | PossiblyDifferent3 a a a
-  deriving stock
-    ( -- | @since 1.0
-      Show
-    )
-
--- | @since 1.0
-pattern Entangled3 :: a -> a -> a -> Entangled3 a
-pattern Entangled3 x y z <- (delta3 -> Just (x, y, z))
-
--- | @since 1.0
-pattern Disentangled3 :: a -> a -> a -> Entangled3 a
-pattern Disentangled3 x y z = PossiblyDifferent3 x y z
-
-{-# COMPLETE Entangled3, Disentangled3 #-}
-
--- | @since 1.0
-instance Arbitrary1 Entangled3 where
-  liftArbitrary gen = do
-    b <- arbitrary
-    x <- gen
-    if b
-      then pure . Same3 $ x
-      else PossiblyDifferent3 x <$> gen <*> gen
-  liftShrink shr = \case
-    Same3 x -> Same3 <$> shr x
-    PossiblyDifferent3 x y z ->
-      PossiblyDifferent3 <$> shr x <*> shr y <*> shr z
-
 -- Helpers
-
--- Helper for the view pattern on Entangled
-delta ::
-  forall (a :: Type).
-  Entangled a ->
-  Maybe (a, a)
-delta = \case
-  Same x -> Just (x, x)
-  PossiblyDifferent _ _ -> Nothing
 
 knownEntangled ::
   forall (a :: Type).
@@ -648,15 +551,6 @@ knownEntangled ::
 knownEntangled = \case
   Entangled _ _ -> True
   _ -> False
-
--- Helper for the view pattern on Entangled3
-delta3 ::
-  forall (a :: Type).
-  Entangled3 a ->
-  Maybe (a, a, a)
-delta3 = \case
-  Same3 x -> Just (x, x, x)
-  PossiblyDifferent3 {} -> Nothing
 
 knownEntangled3 ::
   forall (a :: Type).

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -10,10 +10,14 @@ module Test.Tasty.Plutus.Laws (
   dataLawsWith,
   plutusEqLaws,
   plutusEqLawsWith,
+  plutusEqLawsDirect,
+  plutusEqLawsDirectWith,
   --  plutusOrdLaws,
   --  plutusOrdLawsWith
 
-  -- * Helper type
+  -- * Helper types
+  Pair (..),
+  Triple (..),
   Entangled (Entangled, Disentangled),
   Entangled3 (Entangled3, Disentangled3),
 ) where
@@ -32,7 +36,14 @@ import PlutusTx.IsData.Class (
   toData,
  )
 import PlutusTx.Prelude qualified as PlutusTx
-import Test.QuickCheck (Property, forAllShrinkShow, (.||.), (===))
+import Test.QuickCheck (
+  Property,
+  checkCoverage,
+  cover,
+  forAllShrinkShow,
+  (.||.),
+  (===),
+ )
 import Test.QuickCheck.Arbitrary (
   Arbitrary (arbitrary, shrink),
   Arbitrary1 (liftArbitrary, liftShrink),
@@ -51,14 +62,20 @@ import Text.PrettyPrint (
 import Text.Show.Pretty (ppDoc, ppShow)
 import Type.Reflection (Typeable, tyConName, typeRep, typeRepTyCon)
 
--- | @since 1.0
+{- | Checks that 'ToJSON' and 'FromJSON' for @a@ form a partial isomorphism.
+
+ @since 1.0
+-}
 jsonLaws ::
   forall (a :: Type).
   (Typeable a, ToJSON a, FromJSON a, Arbitrary a, Eq a, Show a) =>
   TestTree
 jsonLaws = jsonLawsWith @a arbitrary shrink
 
--- | @since 1.0
+{- | As 'jsonLaws', but with an explicit generator and shrinker.
+
+ @since 1.0
+-}
 jsonLawsWith ::
   forall (a :: Type).
   (Typeable a, ToJSON a, FromJSON a, Eq a, Show a) =>
@@ -77,14 +94,21 @@ jsonLawsWith gen shr =
     prop2 :: a -> Property
     prop2 x = (decode . encode $ x) === (Just . toJSON $ x)
 
--- | @since 1.0
+{- | Checks that 'ToData' and 'FromData', as well as 'ToData' and
+ 'UnsafeFromData', for @a@ form a partial isomorphism.
+
+ @since 1.0
+-}
 dataLaws ::
   forall (a :: Type).
   (Typeable a, ToData a, UnsafeFromData a, FromData a, Arbitrary a, Eq a, Show a) =>
   TestTree
 dataLaws = dataLawsWith @a arbitrary shrink
 
--- | @since 1.0
+{- | As 'dataLaws', but with an explicit generator and shrinker.
+
+ @since 1.0
+-}
 dataLawsWith ::
   forall (a :: Type).
   (Typeable a, ToData a, FromData a, UnsafeFromData a, Eq a, Show a) =>
@@ -118,14 +142,39 @@ dataLawsWith gen shr =
     go2 :: a -> Property
     go2 x = (unsafeFromBuiltinData . toBuiltinData $ x) === x
 
--- | @since 1.0
+{- | Checks that the 'PlutusTx.Eq' instance for @a@ is an equivalence relation.
+
+ = Note
+
+ This uses a technique to avoid coverage issues arising from a low likelihood
+ of independently generating identical values. This mostly affects those types
+ which have a large, or infinite, number of inhabitants: if your type is
+ finite and small, this will actually have the _opposite_ effect, as it would
+ skew the balance of comparisons the /other/ way.
+
+ To assist with this, coverage checking is built in: if you are seeing errors
+ due to coverage, try using 'plutusEqLawsDirect' instead.
+
+ @since 1.0
+-}
 plutusEqLaws ::
   forall (a :: Type).
   (Typeable a, PlutusTx.Eq a, Arbitrary a, Show a) =>
   TestTree
 plutusEqLaws = plutusEqLawsWith @a arbitrary shrink
 
--- | @since 1.0
+{- | As 'plutusEqLaws', but with an explicit generator and shrinker.
+
+ = Note
+
+ As this function (like 'plutusEqLaws') uses a technique to avoid coverage
+ issues, if your generator is restricted (especially to a small, finite subset
+ of the whole type), you may get test failures due to poor coverage. If this
+ happens, either use 'plutusEqLawsDirectWith', or change the generator to be
+ less constrained.
+
+ @since 1.0
+-}
 plutusEqLawsWith ::
   forall (a :: Type).
   (Typeable a, PlutusTx.Eq a, Show a) =>
@@ -152,16 +201,126 @@ plutusEqLawsWith gen shr =
     propRefl :: a -> Property
     propRefl x = (x PlutusTx.== x) === True
     propSymm :: Entangled a -> Property
-    propSymm ent = case ent of
-      Entangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
-      Disentangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
+    propSymm ent = checkCoverage
+      . cover 50.0 (knownEntangled ent) "precondition known satisfied"
+      $ case ent of
+        Entangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
+        Disentangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
     propTrans :: Entangled3 a -> Property
-    propTrans = \case
-      Entangled3 x y z ->
-        ((x PlutusTx.== y) && (y PlutusTx.== z)) === (x PlutusTx.== z)
-      Disentangled3 x y z ->
-        ((x PlutusTx./= y) || (y PlutusTx./= z))
-          .||. (True === (x PlutusTx.== z))
+    propTrans ent3 = checkCoverage
+      . cover 50.0 (knownEntangled3 ent3) "precondition known satisfied"
+      $ case ent3 of
+        Entangled3 x y z ->
+          ((x PlutusTx.== y) && (y PlutusTx.== z)) === (x PlutusTx.== z)
+        Disentangled3 x y z ->
+          ((x PlutusTx./= y) || (y PlutusTx./= z))
+            .||. (True === (x PlutusTx.== z))
+
+{- | Checks that the 'PlutusTx.Eq' instance for @a@ is an equivalence relation.
+
+ = Note
+
+ This function tests the equivalence relation properties (specifically,
+ symmetry and transitivity) directly, without relying on the
+ coverage-improving technique used in 'plutusEqLaws'. This works if @a@ as a
+ type is both finite and has small cardinality, as in that situation, the
+ distribution of successful and unsuccessful preconditions will roughly match.
+ However, if @a@ is infinite or large, this will cause a skewed case
+ distribution, which will produce misleading results.
+
+ To assist with this, coverage checking is built in to the properties this
+ checks; if you find that your coverage is too low, use 'plutusEqLaws'
+ instead.
+
+ @since 1.0
+-}
+plutusEqLawsDirect ::
+  forall (a :: Type).
+  (Typeable a, PlutusTx.Eq a, Show a, Arbitrary a) =>
+  TestTree
+plutusEqLawsDirect = plutusEqLawsDirectWith @a arbitrary shrink
+
+{- | As 'plutusEqLawsDirect', but with explicit generator and shrinker.
+
+ = Note
+
+ As this function (like 'plutusEqLawsDirect') tests equivalence relation
+ properties directly, either @a@ must be both finite and small, or the
+ generator and shrinker passed to this function must produce only a small and
+ finite subset of the type. See the caveats on the use of 'plutusEqLawsDirect'
+ as to why.
+
+ To assist with this, coverage checking is built in to the properties this
+ checks; if you find that your coverage is too low, use 'plutusEqLaws'
+ instead.
+
+ @since 1.0
+-}
+plutusEqLawsDirectWith ::
+  forall (a :: Type).
+  (Typeable a, PlutusTx.Eq a, Show a) =>
+  Gen a ->
+  (a -> [a]) ->
+  TestTree
+plutusEqLawsDirectWith gen shr =
+  testProperties
+    ("Plutus Eq laws for " <> typeName @a)
+    [
+      ( "x == x"
+      , forAllShrinkShow gen shr ppShow propRefl
+      )
+    ,
+      ( "if x == y, then y == x"
+      , forAllShrinkShow (liftArbitrary gen) (liftShrink shr) ppShow propSymm
+      )
+    ,
+      ( "if x == y and y == z, then x == z"
+      , forAllShrinkShow (liftArbitrary gen) (liftShrink shr) ppShow propTrans
+      )
+    ]
+  where
+    propRefl :: a -> Property
+    propRefl x = (x PlutusTx.== x) === True
+    propSymm :: Pair a -> Property
+    propSymm (Pair x y) =
+      cover 50.0 (x PlutusTx.== y) "precondition satisfied" $
+        (x PlutusTx.== y) === (y PlutusTx.== x)
+    propTrans :: Triple a -> Property
+    propTrans (Triple x y z) =
+      cover
+        50.0
+        ((x PlutusTx.== y) && (y PlutusTx.== z))
+        "precondition satisfied"
+        $ ((x PlutusTx.== y) && (y PlutusTx.== z)) === (x PlutusTx.== z)
+
+-- | @since 1.0
+data Pair (a :: Type) = Pair a a
+  deriving stock
+    ( -- | @since 1.0
+      Functor
+    , -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+instance Arbitrary1 Pair where
+  liftArbitrary gen = Pair <$> gen <*> gen
+  liftShrink shr (Pair x y) = Pair <$> shr x <*> shr y
+
+-- | @since 1.0
+data Triple (a :: Type) = Triple a a a
+  deriving stock
+    ( -- | @since 1.0
+      Functor
+    , -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+instance Arbitrary1 Triple where
+  liftArbitrary gen = Triple <$> gen <*> gen <*> gen
+  liftShrink shr (Triple x y z) =
+    Triple <$> shr x <*> shr y <*> shr z
 
 -- | @since 1.0
 data Entangled (a :: Type)
@@ -229,16 +388,38 @@ instance Arbitrary1 Entangled3 where
 -- Helpers
 
 -- Helper for the view pattern on Entangled
-delta :: Entangled a -> Maybe (a, a)
+delta ::
+  forall (a :: Type).
+  Entangled a ->
+  Maybe (a, a)
 delta = \case
   Same x -> Just (x, x)
   PossiblyDifferent _ _ -> Nothing
 
+knownEntangled ::
+  forall (a :: Type).
+  Entangled a ->
+  Bool
+knownEntangled = \case
+  Entangled _ _ -> True
+  _ -> False
+
 -- Helper for the view pattern on Entangled3
-delta3 :: Entangled3 a -> Maybe (a, a, a)
+delta3 ::
+  forall (a :: Type).
+  Entangled3 a ->
+  Maybe (a, a, a)
 delta3 = \case
   Same3 x -> Just (x, x, x)
   PossiblyDifferent3 {} -> Nothing
+
+knownEntangled3 ::
+  forall (a :: Type).
+  Entangled3 a ->
+  Bool
+knownEntangled3 = \case
+  Entangled3 {} -> True
+  _ -> False
 
 typeName :: forall (a :: Type). (Typeable a) => String
 typeName = tyConName . typeRepTyCon $ typeRep @a

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Test.Tasty.Plutus.Laws (
+  jsonLaws,
+  jsonLawsWith,
+--  dataLaws,
+--  dataLawsWith,
+--  unsafeDataLaws,
+--  unsafeDataLawsWith,
+--  plutusEqLaws,
+--  plutusEqLawsWith,
+--  plutusOrdLaws,
+--  plutusOrdLawsWith
+  ) where
+
+import Data.Text.Encoding (decodeUtf8)
+import Data.Text qualified as T
+import Data.ByteString.Lazy qualified as Lazy
+import Text.PrettyPrint (renderStyle, Style (lineLength), ($+$), 
+  Doc, text, style)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Text.Show.Pretty (ppDoc)
+import Type.Reflection (Typeable, tyConName, typeRepTyCon, typeRep)
+import Test.Tasty.QuickCheck (testProperties)
+import Data.Aeson (ToJSON (toJSON), FromJSON, decode, encode)
+import Data.Kind (Type)
+import Test.Tasty (TestTree)
+import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
+import Test.QuickCheck.Gen (Gen)
+import Test.QuickCheck (forAllShrinkShow, Property, (===)) 
+
+-- | @since 1.0
+jsonLaws :: forall (a :: Type) . 
+  (Typeable a, ToJSON a, FromJSON a, Arbitrary a, Eq a, Show a) => 
+  TestTree
+jsonLaws = jsonLawsWith @a arbitrary shrink
+
+-- | @since 1.0
+jsonLawsWith :: forall (a :: Type) . 
+  (Typeable a, ToJSON a, FromJSON a, Eq a, Show a) => 
+  Gen a -> 
+  (a -> [a]) -> 
+  TestTree
+jsonLawsWith gen shr = testProperties ("JSON laws for " <> typeName @a) [
+  ("decode . encode = Just", forAllShrinkShow gen shr showJSON prop1),
+  ("decode . encode = Just . toJSON", forAllShrinkShow gen shr showJSON prop2)
+  ]
+  where
+    prop1 :: a -> Property
+    prop1 x = (decode . encode $ x) === Just x
+    prop2 :: a -> Property
+    prop2 x = (decode . encode $ x) === (Just . toJSON $ x)
+
+-- Helpers
+
+typeName :: forall (a :: Type) . (Typeable a) => String
+typeName = tyConName . typeRepTyCon $ typeRep @a
+
+showJSON :: forall (a :: Type) . 
+  (Show a, ToJSON a) => a -> String
+showJSON x = renderStyle ourStyle $ 
+  "As data type" $+$
+  "" $+$
+  ppDoc x $+$
+  "" $+$
+  "As JSON" $+$
+  go
+  where
+    go :: Doc
+    go = text . T.unpack . decodeUtf8 . Lazy.toStrict . encodePretty $ x
+
+ourStyle :: Style
+ourStyle = style { lineLength = 80 }

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -1,14 +1,21 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Test.Tasty.Plutus.Laws (
+  -- * Test API
   jsonLaws,
   jsonLawsWith,
   dataLaws,
   dataLawsWith,
-  --  plutusEqLaws,
-  --  plutusEqLawsWith,
+  plutusEqLaws,
+  plutusEqLawsWith,
   --  plutusOrdLaws,
   --  plutusOrdLawsWith
+
+  -- * Helper type
+  Entangled (Entangled, Disentangled),
+  Entangled3 (Entangled3, Disentangled3),
 ) where
 
 import Data.Aeson (FromJSON, ToJSON (toJSON), decode, encode)
@@ -24,8 +31,12 @@ import PlutusTx.IsData.Class (
   fromData,
   toData,
  )
-import Test.QuickCheck (Property, forAllShrinkShow, (===))
-import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
+import PlutusTx.Prelude qualified as PlutusTx
+import Test.QuickCheck (Property, forAllShrinkShow, (.||.), (===))
+import Test.QuickCheck.Arbitrary (
+  Arbitrary (arbitrary, shrink),
+  Arbitrary1 (liftArbitrary, liftShrink),
+ )
 import Test.QuickCheck.Gen (Gen)
 import Test.Tasty (TestTree)
 import Test.Tasty.QuickCheck (testProperties)
@@ -107,7 +118,127 @@ dataLawsWith gen shr =
     go2 :: a -> Property
     go2 x = (unsafeFromBuiltinData . toBuiltinData $ x) === x
 
+-- | @since 1.0
+plutusEqLaws ::
+  forall (a :: Type).
+  (Typeable a, PlutusTx.Eq a, Arbitrary a, Show a) =>
+  TestTree
+plutusEqLaws = plutusEqLawsWith @a arbitrary shrink
+
+-- | @since 1.0
+plutusEqLawsWith ::
+  forall (a :: Type).
+  (Typeable a, PlutusTx.Eq a, Show a) =>
+  Gen a ->
+  (a -> [a]) ->
+  TestTree
+plutusEqLawsWith gen shr =
+  testProperties
+    ("Plutus Eq laws for " <> typeName @a)
+    [
+      ( "x == x"
+      , forAllShrinkShow gen shr ppShow propRefl
+      )
+    ,
+      ( "if x == y, then y == x"
+      , forAllShrinkShow (liftArbitrary gen) (liftShrink shr) ppShow propSymm
+      )
+    ,
+      ( "if x == y and y == z, then x == z"
+      , forAllShrinkShow (liftArbitrary gen) (liftShrink shr) ppShow propTrans
+      )
+    ]
+  where
+    propRefl :: a -> Property
+    propRefl x = (x PlutusTx.== x) === True
+    propSymm :: Entangled a -> Property
+    propSymm ent = case ent of
+      Entangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
+      Disentangled x y -> (x PlutusTx.== y) === (y PlutusTx.== x)
+    propTrans :: Entangled3 a -> Property
+    propTrans = \case
+      Entangled3 x y z ->
+        ((x PlutusTx.== y) && (y PlutusTx.== z)) === (x PlutusTx.== z)
+      Disentangled3 x y z ->
+        ((x PlutusTx./= y) || (y PlutusTx./= z))
+          .||. (True === (x PlutusTx.== z))
+
+-- | @since 1.0
+data Entangled (a :: Type)
+  = Same a
+  | PossiblyDifferent a a
+  deriving stock
+    ( -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+pattern Entangled :: a -> a -> Entangled a
+pattern Entangled x y <- (delta -> Just (x, y))
+
+-- | @since 1.0
+pattern Disentangled :: a -> a -> Entangled a
+pattern Disentangled x y <- PossiblyDifferent x y
+
+{-# COMPLETE Entangled, Disentangled #-}
+
+-- | @since 1.0
+instance Arbitrary1 Entangled where
+  liftArbitrary gen = do
+    b <- arbitrary
+    x <- gen
+    if b
+      then pure . Same $ x
+      else PossiblyDifferent x <$> gen
+  liftShrink shr = \case
+    Same x -> Same <$> shr x
+    PossiblyDifferent x y -> PossiblyDifferent <$> shr x <*> shr y
+
+-- | @since 1.0
+data Entangled3 (a :: Type)
+  = Same3 a
+  | PossiblyDifferent3 a a a
+  deriving stock
+    ( -- | @since 1.0
+      Show
+    )
+
+-- | @since 1.0
+pattern Entangled3 :: a -> a -> a -> Entangled3 a
+pattern Entangled3 x y z <- (delta3 -> Just (x, y, z))
+
+-- | @since 1.0
+pattern Disentangled3 :: a -> a -> a -> Entangled3 a
+pattern Disentangled3 x y z = PossiblyDifferent3 x y z
+
+{-# COMPLETE Entangled3, Disentangled3 #-}
+
+-- | @since 1.0
+instance Arbitrary1 Entangled3 where
+  liftArbitrary gen = do
+    b <- arbitrary
+    x <- gen
+    if b
+      then pure . Same3 $ x
+      else PossiblyDifferent3 x <$> gen <*> gen
+  liftShrink shr = \case
+    Same3 x -> Same3 <$> shr x
+    PossiblyDifferent3 x y z ->
+      PossiblyDifferent3 <$> shr x <*> shr y <*> shr z
+
 -- Helpers
+
+-- Helper for the view pattern on Entangled
+delta :: Entangled a -> Maybe (a, a)
+delta = \case
+  Same x -> Just (x, x)
+  PossiblyDifferent _ _ -> Nothing
+
+-- Helper for the view pattern on Entangled3
+delta3 :: Entangled3 a -> Maybe (a, a, a)
+delta3 = \case
+  Same3 x -> Just (x, x, x)
+  PossiblyDifferent3 {} -> Nothing
 
 typeName :: forall (a :: Type). (Typeable a) => String
 typeName = tyConName . typeRepTyCon $ typeRep @a

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -3,71 +3,126 @@
 module Test.Tasty.Plutus.Laws (
   jsonLaws,
   jsonLawsWith,
---  dataLaws,
---  dataLawsWith,
---  unsafeDataLaws,
---  unsafeDataLawsWith,
---  plutusEqLaws,
---  plutusEqLawsWith,
---  plutusOrdLaws,
---  plutusOrdLawsWith
-  ) where
+  dataLaws,
+  dataLawsWith,
+  --  unsafeDataLaws,
+  --  unsafeDataLawsWith,
+  --  plutusEqLaws,
+  --  plutusEqLawsWith,
+  --  plutusOrdLaws,
+  --  plutusOrdLawsWith
+) where
 
-import Data.Text.Encoding (decodeUtf8)
-import Data.Text qualified as T
-import Data.ByteString.Lazy qualified as Lazy
-import Text.PrettyPrint (renderStyle, Style (lineLength), ($+$), 
-  Doc, text, style)
+import Data.Aeson (FromJSON, ToJSON (toJSON), decode, encode)
 import Data.Aeson.Encode.Pretty (encodePretty)
-import Text.Show.Pretty (ppDoc)
-import Type.Reflection (Typeable, tyConName, typeRepTyCon, typeRep)
-import Test.Tasty.QuickCheck (testProperties)
-import Data.Aeson (ToJSON (toJSON), FromJSON, decode, encode)
+import Data.ByteString.Lazy qualified as Lazy
 import Data.Kind (Type)
-import Test.Tasty (TestTree)
+import Data.Text qualified as T
+import Data.Text.Encoding (decodeUtf8)
+import PlutusTx.IsData.Class (
+  FromData (fromBuiltinData),
+  ToData (toBuiltinData),
+  fromData,
+  toData,
+ )
+import Test.QuickCheck (Property, forAllShrinkShow, (===))
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
 import Test.QuickCheck.Gen (Gen)
-import Test.QuickCheck (forAllShrinkShow, Property, (===)) 
+import Test.Tasty (TestTree)
+import Test.Tasty.QuickCheck (testProperties)
+import Text.PrettyPrint (
+  Doc,
+  Style (lineLength),
+  renderStyle,
+  style,
+  text,
+  ($+$),
+ )
+import Text.Show.Pretty (ppDoc, ppShow)
+import Type.Reflection (Typeable, tyConName, typeRep, typeRepTyCon)
 
 -- | @since 1.0
-jsonLaws :: forall (a :: Type) . 
-  (Typeable a, ToJSON a, FromJSON a, Arbitrary a, Eq a, Show a) => 
+jsonLaws ::
+  forall (a :: Type).
+  (Typeable a, ToJSON a, FromJSON a, Arbitrary a, Eq a, Show a) =>
   TestTree
 jsonLaws = jsonLawsWith @a arbitrary shrink
 
 -- | @since 1.0
-jsonLawsWith :: forall (a :: Type) . 
-  (Typeable a, ToJSON a, FromJSON a, Eq a, Show a) => 
-  Gen a -> 
-  (a -> [a]) -> 
+jsonLawsWith ::
+  forall (a :: Type).
+  (Typeable a, ToJSON a, FromJSON a, Eq a, Show a) =>
+  Gen a ->
+  (a -> [a]) ->
   TestTree
-jsonLawsWith gen shr = testProperties ("JSON laws for " <> typeName @a) [
-  ("decode . encode = Just", forAllShrinkShow gen shr showJSON prop1),
-  ("decode . encode = Just . toJSON", forAllShrinkShow gen shr showJSON prop2)
-  ]
+jsonLawsWith gen shr =
+  testProperties
+    ("JSON laws for " <> typeName @a)
+    [ ("decode . encode = Just", forAllShrinkShow gen shr showJSON prop1)
+    , ("decode . encode = Just . toJSON", forAllShrinkShow gen shr showJSON prop2)
+    ]
   where
     prop1 :: a -> Property
     prop1 x = (decode . encode $ x) === Just x
     prop2 :: a -> Property
     prop2 x = (decode . encode $ x) === (Just . toJSON $ x)
 
+-- | @since 1.0
+dataLaws ::
+  forall (a :: Type).
+  (Typeable a, ToData a, FromData a, Arbitrary a, Eq a, Show a) =>
+  TestTree
+dataLaws = dataLawsWith @a arbitrary shrink
+
+-- | @since 1.0
+dataLawsWith ::
+  forall (a :: Type).
+  (Typeable a, ToData a, FromData a, Eq a, Show a) =>
+  Gen a ->
+  (a -> [a]) ->
+  TestTree
+dataLawsWith gen shr =
+  testProperties
+    ("Data laws for " <> typeName @a)
+    [
+      ( "fromBuiltinData . toBuiltinData = Just"
+      , forAllShrinkShow gen shr ppShow (go fromBuiltinData toBuiltinData)
+      )
+    ,
+      ( "fromData . toData = Just"
+      , forAllShrinkShow gen shr ppShow (go fromData toData)
+      )
+    ]
+  where
+    go ::
+      forall (b :: Type).
+      (b -> Maybe a) ->
+      (a -> b) ->
+      a ->
+      Property
+    go from to x = (from . to $ x) === Just x
+
 -- Helpers
 
-typeName :: forall (a :: Type) . (Typeable a) => String
+typeName :: forall (a :: Type). (Typeable a) => String
 typeName = tyConName . typeRepTyCon $ typeRep @a
 
-showJSON :: forall (a :: Type) . 
-  (Show a, ToJSON a) => a -> String
-showJSON x = renderStyle ourStyle $ 
-  "As data type" $+$
-  "" $+$
-  ppDoc x $+$
-  "" $+$
-  "As JSON" $+$
-  go
+showJSON ::
+  forall (a :: Type).
+  (Show a, ToJSON a) =>
+  a ->
+  String
+showJSON x =
+  renderStyle ourStyle $
+    "As data type"
+      $+$ ""
+      $+$ ppDoc x
+      $+$ ""
+      $+$ "As JSON"
+      $+$ go
   where
     go :: Doc
     go = text . T.unpack . decodeUtf8 . Lazy.toStrict . encodePretty $ x
 
 ourStyle :: Style
-ourStyle = style { lineLength = 80 }
+ourStyle = style {lineLength = 80}

--- a/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Laws.hs
@@ -1,5 +1,30 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
+{- |
+ Module: Test.Tasty.Plutus.Laws
+ Copyright: (C) MLabs 2021
+ License: Apache 2.0
+ Maintainer: Koz Ross <koz@mlabs.city>
+ Portability: GHC only
+ Stability: Experimental
+
+ Allows for automatically testing various type class laws using QuickCheck.
+
+ Can be used like so:
+
+ > import Test.Tasty.Plutus.Laws (jsonLaws, dataLawsWith)
+ >
+ > myLawsTests :: TestTree
+ > myLawsTests = testGroup "Laws" [
+ >    jsonLaws @MyType,
+ >    dataLawsWith myGen myShrinker
+ >    ...
+
+ = Note
+
+ This module's API is a wrapper around @tasty-quickcheck@; thus, all options
+ used by @tasty-quickcheck@ can also be used here.
+-}
 module Test.Tasty.Plutus.Laws (
   -- * Test API
 
@@ -28,12 +53,6 @@ module Test.Tasty.Plutus.Laws (
   plutusSemigroupLawsWith,
   plutusMonoidLaws,
   plutusMonoidLawsWith,
-
-  -- * Helper types
-  Pair (..),
-  Triple (..),
-  Entangled (Entangled, Disentangled),
-  Entangled3 (Entangled3, Disentangled3),
 ) where
 
 import Data.Aeson (FromJSON, ToJSON (toJSON), decode, encode)

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -106,3 +106,13 @@ test-suite golden
     , plutus-tx
 
   hs-source-dirs: test/golden
+
+test-suite laws
+  import:         test-lang
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+  build-depends:
+    , plutus-laws       ^>=1.0
+    , tasty-quickcheck  ^>=0.10.1.2
+
+  hs-source-dirs: test/laws

--- a/plutus-numeric/test/laws/Main.hs
+++ b/plutus-numeric/test/laws/Main.hs
@@ -3,7 +3,12 @@ module Main (main) where
 import PlutusTx.NatRatio (NatRatio)
 import PlutusTx.Natural (Natural)
 import Test.Tasty (adjustOption, defaultMain, testGroup)
-import Test.Tasty.Plutus.Laws (dataLaws, jsonLaws, plutusEqLaws)
+import Test.Tasty.Plutus.Laws (
+  dataLaws,
+  jsonLaws,
+  plutusEqLaws,
+  plutusOrdLaws,
+ )
 import Test.Tasty.QuickCheck (QuickCheckTests)
 
 main :: IO ()
@@ -15,6 +20,8 @@ main =
     , dataLaws @NatRatio
     , plutusEqLaws @Natural
     , plutusEqLaws @NatRatio
+    , plutusOrdLaws @Natural
+    , plutusOrdLaws @NatRatio
     ]
   where
     testMinimum :: QuickCheckTests

--- a/plutus-numeric/test/laws/Main.hs
+++ b/plutus-numeric/test/laws/Main.hs
@@ -1,0 +1,16 @@
+module Main (main) where
+
+import PlutusTx.Natural (Natural)
+import PlutusTx.NatRatio (NatRatio)
+import Test.Tasty (defaultMain, testGroup, adjustOption)
+import Test.Tasty.Plutus.Laws (jsonLaws)
+import Test.Tasty.QuickCheck (QuickCheckTests)
+
+main :: IO ()
+main = defaultMain . adjustOption (max testMinimum) . testGroup "Laws" $ [
+  jsonLaws @Natural,
+  jsonLaws @NatRatio
+  ]
+  where
+    testMinimum :: QuickCheckTests
+    testMinimum = 10000

--- a/plutus-numeric/test/laws/Main.hs
+++ b/plutus-numeric/test/laws/Main.hs
@@ -1,16 +1,19 @@
 module Main (main) where
 
-import PlutusTx.Natural (Natural)
 import PlutusTx.NatRatio (NatRatio)
-import Test.Tasty (defaultMain, testGroup, adjustOption)
-import Test.Tasty.Plutus.Laws (jsonLaws)
+import PlutusTx.Natural (Natural)
+import Test.Tasty (adjustOption, defaultMain, testGroup)
+import Test.Tasty.Plutus.Laws (dataLaws, jsonLaws)
 import Test.Tasty.QuickCheck (QuickCheckTests)
 
 main :: IO ()
-main = defaultMain . adjustOption (max testMinimum) . testGroup "Laws" $ [
-  jsonLaws @Natural,
-  jsonLaws @NatRatio
-  ]
+main =
+  defaultMain . adjustOption (max testMinimum) . testGroup "Laws" $
+    [ jsonLaws @Natural
+    , jsonLaws @NatRatio
+    , dataLaws @Natural
+    , dataLaws @NatRatio
+    ]
   where
     testMinimum :: QuickCheckTests
     testMinimum = 10000

--- a/plutus-numeric/test/laws/Main.hs
+++ b/plutus-numeric/test/laws/Main.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import PlutusTx.NatRatio (NatRatio)
 import PlutusTx.Natural (Natural)
 import Test.Tasty (adjustOption, defaultMain, testGroup)
-import Test.Tasty.Plutus.Laws (dataLaws, jsonLaws)
+import Test.Tasty.Plutus.Laws (dataLaws, jsonLaws, plutusEqLaws)
 import Test.Tasty.QuickCheck (QuickCheckTests)
 
 main :: IO ()
@@ -13,6 +13,8 @@ main =
     , jsonLaws @NatRatio
     , dataLaws @Natural
     , dataLaws @NatRatio
+    , plutusEqLaws @Natural
+    , plutusEqLaws @NatRatio
     ]
   where
     testMinimum :: QuickCheckTests


### PR DESCRIPTION
This introduces `plutus-laws` for checking various type class laws with QuickCheck. These checks have been incorporated into `plutus-numeric`'s test suite where appropriate.