### PR TITLE
Add wrappers for numeric conversions, tests for their consistency

### DIFF
--- a/plutus-numeric/CHANGELOG.md
+++ b/plutus-numeric/CHANGELOG.md
@@ -4,11 +4,19 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 2.1 -- 2021-11-15
+
+### Added
+
+- `natToInteger` and `natRatioToRational` as dedicated (and clearer) aliases for
+  `addExtend`.
+
 ## 2.0 -- 2021-11-11
 
-- Plutus upgraded
-  - `plutus` pinned to `3f089ccf0ca746b399c99afe51e063b0640af547`
-  - `plutus-apps` pinned to `404af7ac3e27ebcb218c05f79d9a70ca966407c9`
+### Changed
+
+- Plutus upgrade: `plutus` pinned to `3f089ccf0ca746b399c99afe51e063b0640af547`, 
+  `plutus-apps` pinned to `404af7ac3e27ebcb218c05f79d9a70ca966407c9`
 
 ## 1.1 -- 2021-10-28
 

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-numeric
-version:            2.0
+version:            2.1
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -84,6 +84,7 @@ test-suite property
   other-modules:
     Compilation
     Helpers
+    Suites.Consistency
     Suites.NatRatio
     Suites.Natural
     Suites.Numeric

--- a/plutus-numeric/src/PlutusTx/NatRatio.hs
+++ b/plutus-numeric/src/PlutusTx/NatRatio.hs
@@ -31,7 +31,20 @@ module PlutusTx.NatRatio (
   Internal.properFraction,
   Internal.recip,
   Internal.toRational,
+
+  -- ** Conversion
+  natRatioToRational,
 ) where
 
 import PlutusTx.NatRatio.Internal qualified as Internal
 import PlutusTx.NatRatio.QQ qualified as QQ
+import PlutusTx.Numeric.Extra (addExtend)
+import PlutusTx.Ratio qualified as Ratio
+
+{- | The same as 'addExtend', but specialized for the 'Internal.NatRatio' to
+ 'Ratio.Rational' case.
+
+ @since 2.1
+-}
+natRatioToRational :: Internal.NatRatio -> Ratio.Rational
+natRatioToRational = addExtend

--- a/plutus-numeric/src/PlutusTx/Natural.hs
+++ b/plutus-numeric/src/PlutusTx/Natural.hs
@@ -20,7 +20,18 @@ module PlutusTx.Natural (
 
   -- * Functions
   Internal.parity,
+  natToInteger,
 ) where
 
 import PlutusTx.Natural.Internal as Internal
 import PlutusTx.Natural.QQ as QQ
+import PlutusTx.Numeric.Extra (addExtend)
+import PlutusTx.Prelude qualified as PTx
+
+{- | The same as 'addExtend', but specialized for the
+ 'Internal.Natural' to 'PTx.Integer' case.
+
+ @since 2.1
+-}
+natToInteger :: Internal.Natural -> PTx.Integer
+natToInteger = addExtend

--- a/plutus-numeric/test/property/Main.hs
+++ b/plutus-numeric/test/property/Main.hs
@@ -2,6 +2,7 @@ module Main (main) where
 
 -- ensures compilation on-chain gets tested
 import Compilation ()
+import Suites.Consistency qualified as Consistency
 import Suites.NatRatio qualified as NatRatio
 import Suites.Natural qualified as Natural
 import Suites.Numeric qualified as Numeric
@@ -13,4 +14,5 @@ main =
     [ testGroup "Natural" Natural.tests
     , testGroup "NatRatio" NatRatio.tests
     , testGroup "Numeric.Extra instances for Plutus builtins" Numeric.tests
+    , testGroup "Consistency" Consistency.tests
     ]

--- a/plutus-numeric/test/property/Suites/Consistency.hs
+++ b/plutus-numeric/test/property/Suites/Consistency.hs
@@ -1,0 +1,34 @@
+module Suites.Consistency (tests) where
+
+import PlutusTx.NatRatio (NatRatio, natRatioToRational)
+import PlutusTx.Natural (Natural, natToInteger)
+import PlutusTx.Numeric.Extra (addExtend)
+import Test.QuickCheck (Property, forAllShrink, (===))
+import Test.QuickCheck.Arbitrary (arbitrary, shrink)
+import Test.Tasty (TestTree, adjustOption, testGroup)
+import Test.Tasty.QuickCheck (QuickCheckTests, testProperty)
+
+tests :: [TestTree]
+tests =
+  [ adjustOption go . testGroup "Wrapped operations must be consistent" $
+      [ testProperty "natToInteger must be consistent with addExtend" natToIntegerProp
+      , testProperty "natRatioToRatio must be consistent with addExtend" natRatioToRationalProp
+      ]
+  ]
+  where
+    go :: QuickCheckTests -> QuickCheckTests
+    go = max 100000
+
+-- Helpers
+
+natToIntegerProp :: Property
+natToIntegerProp = forAllShrink arbitrary shrink go
+  where
+    go :: Natural -> Property
+    go n = addExtend n === natToInteger n
+
+natRatioToRationalProp :: Property
+natRatioToRationalProp = forAllShrink arbitrary shrink go
+  where
+    go :: NatRatio -> Property
+    go nr = addExtend nr === natRatioToRational nr

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -70,7 +70,7 @@ library
     , plutus-contract
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-numeric     ^>=2.0
+    , plutus-numeric     ^>=2.1
     , plutus-pretty      ^>=2.0
     , plutus-tx
     , pretty             ^>=1.1.3.6


### PR DESCRIPTION
This provides `natToInteger` and `natRatioToRational` as monomorphic wrappers around `addExtend`.