### PR TITLE
Substitution testing for Plutus Eq

### DIFF
--- a/plutus-laws/CHANGELOG.md
+++ b/plutus-laws/CHANGELOG.md
@@ -4,11 +4,19 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 2.1 -- 2021-11-16
+
+### Added
+
+* Substitution testing for Plutus `Eq`.
+* `PA` type as a Plutus version of QuickCheck's `A`.
+
 ## 2.0 -- 2021-11-11
 
-- Plutus upgraded
-  - `plutus` pinned to `3f089ccf0ca746b399c99afe51e063b0640af547`
-  - `plutus-apps` pinned to `404af7ac3e27ebcb218c05f79d9a70ca966407c9`
+### Changed
+
+* Plutus upgrade: `plutus` pinned to `3f089ccf0ca746b399c99afe51e063b0640af547`,
+  `plutus-apps` pinned to `404af7ac3e27ebcb218c05f79d9a70ca966407c9`
 
 ## 1.0 -- 2021-11-03
 

--- a/plutus-laws/plutus-laws.cabal
+++ b/plutus-laws/plutus-laws.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-laws
-version:            2.0
+version:            2.1
 extra-source-files: CHANGELOG.md
 
 common lang

--- a/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
+++ b/plutus-laws/src/Test/Tasty/Plutus/Arbitrary.hs
@@ -16,13 +16,19 @@ module Test.Tasty.Plutus.Arbitrary (
   Triple (..),
   Entangled (Entangled, Disentangled),
   Entangled3 (Entangled3, Disentangled3),
+  PA,
 ) where
 
 import Data.Kind (Type)
+import PlutusTx.Prelude qualified as PlutusTx
 import Test.QuickCheck.Arbitrary (
+  Arbitrary,
   Arbitrary1 (liftArbitrary, liftShrink),
+  CoArbitrary,
   arbitrary,
  )
+import Test.QuickCheck.Function (Function (function), functionMap)
+import Test.QuickCheck.Poly (A (A))
 
 {- | A single-type tuple. Its 'Arbitrary1' instance makes it convenient to
  generate pairs of the same type with an explicit generator:
@@ -198,6 +204,40 @@ instance Arbitrary1 Entangled3 where
     Same3 x -> Same3 <$> shr x
     PossiblyDifferent3 x y z ->
       PossiblyDifferent3 <$> shr x <*> shr y <*> shr z
+
+{- | A newtype wrapper for testing polymorphic properties. This is mostly useful
+ for function tests involving 'CoArbitrary' and 'Function', when the result
+ type isn't important. This newtype also defines several instances of Plutus
+ type classes (hence 'PA'), but is otherwise identical to 'A' from QuickCheck.
+
+ @since 2.1
+-}
+newtype PA = PA A
+  deriving
+    ( -- | @since 2.1
+      Eq
+    , -- | @since 2.1
+      Show
+    , -- | @since 2.1
+      Arbitrary
+    , -- | @since 2.1
+      CoArbitrary
+    )
+    via A
+  deriving
+    ( -- | @since 2.1
+      PlutusTx.Eq
+    , -- | @since 2.1
+      PlutusTx.Ord
+    )
+    via Integer
+
+-- | @since 2.1
+instance Function PA where
+  function = functionMap into PA
+    where
+      into :: PA -> A
+      into (PA x) = x
 
 -- Helpers
 

--- a/plutus-numeric/CHANGELOG.md
+++ b/plutus-numeric/CHANGELOG.md
@@ -4,6 +4,12 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 2.2 -- 2021-11-17
+
+### Added
+
+* `CoArbitrary` and `Function` instances for `Natural` and `NatRatio`.
+
 ## 2.1 -- 2021-11-15
 
 ### Added

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-numeric
-version:            2.1
+version:            2.2
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -113,7 +113,7 @@ test-suite laws
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   build-depends:
-    , plutus-laws       ^>=2.0
+    , plutus-laws       ^>=2.1
     , tasty-quickcheck  ^>=0.10.1.2
 
   hs-source-dirs: test/laws

--- a/plutus-numeric/src/PlutusTx/Natural/Internal.hs
+++ b/plutus-numeric/src/PlutusTx/Natural/Internal.hs
@@ -22,7 +22,11 @@ import PlutusTx.IsData (
 import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude hiding (even)
 import Schema (ToArgument, ToSchema)
-import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary, shrink))
+import Test.QuickCheck.Arbitrary (
+  Arbitrary (arbitrary, shrink),
+  CoArbitrary,
+ )
+import Test.QuickCheck.Function (Function (function), functionMap)
 import Text.Show.Pretty (PrettyVal (prettyVal), Value (Con))
 import Prelude qualified
 
@@ -58,6 +62,8 @@ newtype Natural = Natural Integer
       Prelude.Ord
     , -- | @since 1.0
       OpenApi.ToSchema
+    , -- | @since 2.2
+      CoArbitrary
     )
     via Integer
   deriving stock
@@ -128,6 +134,13 @@ instance Enum Natural where
 instance Arbitrary Natural where
   arbitrary = Natural . Prelude.abs Prelude.<$> arbitrary
   shrink (Natural i) = Natural Prelude.<$> (Prelude.filter (> 0) . shrink $ i)
+
+-- | @since 2.2
+instance Function Natural where
+  function = functionMap into Natural
+    where
+      into :: Natural -> Integer
+      into (Natural i) = i
 
 {- | A demonstration of the parity of a number.
 

--- a/plutus-numeric/test/laws/Main.hs
+++ b/plutus-numeric/test/laws/Main.hs
@@ -7,6 +7,7 @@ import Test.Tasty.Plutus.Laws (
   dataLaws,
   jsonLaws,
   plutusEqLaws,
+  plutusEqLawsSubstitution,
   plutusOrdLaws,
  )
 import Test.Tasty.QuickCheck (QuickCheckTests)
@@ -19,7 +20,9 @@ main =
     , dataLaws @Natural
     , dataLaws @NatRatio
     , plutusEqLaws @Natural
+    , plutusEqLawsSubstitution @Natural
     , plutusEqLaws @NatRatio
+    , plutusEqLawsSubstitution @NatRatio
     , plutusOrdLaws @Natural
     , plutusOrdLaws @NatRatio
     ]

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -70,7 +70,7 @@ library
     , plutus-contract
     , plutus-ledger
     , plutus-ledger-api
-    , plutus-numeric     ^>=2.1
+    , plutus-numeric     ^>=2.2
     , plutus-pretty      ^>=2.0
     , plutus-tx
     , pretty             ^>=1.1.3.6


### PR DESCRIPTION
This also provides `CoArbitrary` and `Function` instances for `Natural` and `NatRatio` to support such testing (as well as other function-based QuickCheck testing). Closes #67.