### PR TITLE
Add helpers to create incomplete contexts

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,11 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 4.1 -- 2021-11-18
+
+* Added `makeIncompleteContexts` to ease building of contexts that are missing
+  a single portion of the context.
+
 ## 4.0 -- 2021-11-11
 
 - Plutus upgraded

--- a/tasty-plutus/src/Test/Tasty/Plutus/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Context.hs
@@ -58,6 +58,9 @@ module Test.Tasty.Plutus.Context (
   -- ** Minting
   mintsWithSelf,
   mintsValue,
+
+  -- ** Combining Contexts
+  makeIncompleteContexts,
 ) where
 
 import Data.Kind (Type)
@@ -75,6 +78,7 @@ import Test.Tasty.Plutus.Internal.Context (
   Minting (OtherMint, OwnMint),
   Output (Output),
   Purpose (ForMinting, ForSpending),
+  makeIncompleteContexts,
  )
 import Wallet.Emulator.Types (Wallet, walletPubKeyHash)
 

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
@@ -222,20 +222,23 @@ compileMinting conf cb =
      context, and the second is the test message when
      that particular context is missing. e.g.
 
-     >>> makeIncompleteContexts
-     >>>   [ (context1, "Missing context 1")
-     >>>   , (context2, "Missing context 2")
-     >>>   , (context3, "Missing context 3")
-     >>>   ]
-     [ (context2 <> context3, "Missing context 1")
-     , (context1 <> context3, "Missing context 2")
-     , (context1 <> context2, "Missing context 3")
-     ]
+     > makeIncompleteContexts
+     >   [ (context1, "Missing context 1")
+     >   , (context2, "Missing context 2")
+     >   , (context3, "Missing context 3")
+     >   ]
+
+     is equivalent to
+
+     > [ (context2 <> context3, "Missing context 1")
+     > , (context1 <> context3, "Missing context 2")
+     > , (context1 <> context2, "Missing context 3")
+     > ]
 
      This can then be run in a `withValidator` block
      like so:
 
-     >>> mapM_ (\(ctx,str) -> shouldn'tValidate str input ctx) convertedContexts
+     > mapM_ (\(ctx,str) -> shouldn'tValidate str input ctx) convertedContexts
 
  @since 4.1
 -}

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
@@ -8,10 +8,15 @@ module Test.Tasty.Plutus.Internal.Context (
   ContextBuilder (..),
   compileSpending,
   compileMinting,
+  makeIncompleteContexts,
 ) where
 
+import Control.Arrow ((***))
+import Data.Bifunctor (first)
 import Data.Kind (Type)
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
+import Data.Semigroup (sconcat)
 import Data.Sequence (Seq)
 import GHC.Exts (toList)
 import Ledger.Scripts (datumHash)
@@ -49,7 +54,9 @@ import Plutus.V1.Ledger.Api (
  )
 import Plutus.V1.Ledger.Time (POSIXTime)
 import Plutus.V1.Ledger.Value qualified as Value
+import PlutusTx.Prelude (length)
 import Test.Tasty.Plutus.Options (ScriptInputPosition (Head, Tail))
+import Prelude hiding (length)
 
 {- | Describes what kind of script this is meant to test. Directly
  corresponds to 'ScriptPurpose'.
@@ -208,6 +215,26 @@ compileMinting conf cb =
     go :: TxInfo
     go = baseTxInfo conf cb
 
+{- | Combine a list of partial contexts that should,
+     when combined, validate, but fail when any one
+     partial context is missing. The input is a list
+     of pairs where the first element is the partial
+     context, and the second is the test message when
+     that particular context is missing.
+
+ @since
+-}
+makeIncompleteContexts ::
+  forall (p :: Purpose).
+  [(ContextBuilder p, String)] ->
+  [(ContextBuilder p, String)]
+makeIncompleteContexts ctxs = map (first sconcat) ctxs2
+  where
+    ctxs1 = removeContext ctxs
+    ctxs2 = mapMaybe nonEmpty1st ctxs1
+    nonEmpty1st :: ([a], b) -> Maybe (NonEmpty.NonEmpty a, b)
+    nonEmpty1st (xs, y) = (,y) <$> NonEmpty.nonEmpty xs
+
 -- Helpers
 
 baseTxInfo ::
@@ -279,3 +306,23 @@ toTxOut valHash (Output typ v) = case typ of
     TxOut (scriptHashAddress hash) v . justDatumHash $ dat
   OwnType dat ->
     TxOut (scriptHashAddress valHash) v . justDatumHash $ dat
+
+-- Helper for makeIncompleteContexts : Take a list
+-- of pairs, and create another list of pairs where
+-- the first element is the concatenation of every
+-- element but the n-th, and the second element is
+-- the second element of the pair that was removed.
+removeContext :: [(a, b)] -> [([a], b)]
+removeContext xs =
+  mapMaybe
+    (maybe2nd . (map fst *** fmap snd) . (`removeNth` xs))
+    [0 .. (length xs - 1)]
+  where
+    maybe2nd :: (a, Maybe b) -> Maybe (a, b)
+    maybe2nd (x, y) = (x,) <$> y
+
+-- Remove and return the n-th element of a list.
+removeNth :: Integer -> [a] -> ([a], Maybe a)
+removeNth _ [] = ([], Nothing)
+removeNth 0 (x : xs) = (xs, Just x)
+removeNth n (x : xs) = first (x :) $ removeNth (n - 1) xs

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
@@ -220,9 +220,24 @@ compileMinting conf cb =
      partial context is missing. The input is a list
      of pairs where the first element is the partial
      context, and the second is the test message when
-     that particular context is missing.
+     that particular context is missing. e.g.
 
- @since
+     >>> makeIncompleteContexts
+     >>>   [ (context1, "Missing context 1")
+     >>>   , (context2, "Missing context 2")
+     >>>   , (context3, "Missing context 3")
+     >>>   ]
+     [ (context2 <> context3, "Missing context 1")
+     , (context1 <> context3, "Missing context 2")
+     , (context1 <> context2, "Missing context 3")
+     ]
+
+     This can then be run in a `withValidator` block
+     like so:
+
+     >>> mapM_ (\(ctx,str) -> shouldn'tValidate str input ctx) convertedContexts
+
+ @since 4.1
 -}
 makeIncompleteContexts ::
   forall (p :: Purpose).


### PR DESCRIPTION
Adds a way to convert a list of partial contexts into a list of almost complete contexts that are each missing exactly one of the partial contexts.