### PR TITLE
[WIP] Enrich TestData and Generator types with script type type argument.

### DIFF
--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
@@ -88,10 +88,10 @@ prepareConf getOpts env =
     scriptInputPosition' = lookupOption opts
 
 getScriptContext ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (s :: Type) (p :: Purpose).
   (a -> TransactionConfig) ->
   (a -> ContextBuilder p) ->
-  (a -> TestData p) ->
+  (a -> TestData s p) ->
   a ->
   ScriptContext
 getScriptContext getConf getCb getTd env = case getTd env of
@@ -111,9 +111,9 @@ getContext ::
 getContext getSc = Context . toBuiltinData . getSc
 
 getScriptResult ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (s :: Type) (p :: Purpose).
   (a -> SomeScript p) ->
-  (a -> TestData p) ->
+  (a -> TestData s p) ->
   (a -> Context) ->
   a ->
   Either ScriptError ([Text], ScriptResult)

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
@@ -133,10 +133,10 @@ didn'tLog getDumpedState env =
       $+$ getDumpedState env
 
 dumpState ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (s :: Type) (p :: Purpose).
   (a -> TransactionConfig) ->
   (a -> ContextBuilder p) ->
-  (a -> TestData p) ->
+  (a -> TestData s p) ->
   [Text] ->
   a ->
   Doc
@@ -165,10 +165,10 @@ dumpState getConf getCb getTd logs env =
           $+$ ppDoc v
 
 dumpState' ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (s :: Type) (p :: Purpose).
   (a -> TransactionConfig) ->
   (a -> ContextBuilder p) ->
-  (a -> TestData p) ->
+  (a -> TestData s p) ->
   [Text] ->
   a ->
   Doc


### PR DESCRIPTION
The goal of this PR is to resolve issues arising from ` (TestData p -> ContextBuilder p) ` in:

```haskell
scriptProperty ::
  forall (p :: Purpose).
  String ->
  Generator p ->
  (TestData p -> ContextBuilder p) ->
  WithScript p ()
```
which expects API user to operate on polymorphic datum and redeemer in this 'callback'. This limits some usage scenarios where user might want to  do more elaborate contextbuilder preparation knowing some information about script for which TestData was generated.

