### PR TITLE
Extensible plutus-laws

### DIFF
--- a/plutus-deriving/plutus-deriving.cabal
+++ b/plutus-deriving/plutus-deriving.cabal
@@ -88,7 +88,7 @@ test-suite laws
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   build-depends:
-    , plutus-laws       ^>=2.2
+    , plutus-laws       ^>=2.3
     , plutus-tx
     , tasty-quickcheck  ^>=0.10.1.2
     , testlib

--- a/plutus-laws/CHANGELOG.md
+++ b/plutus-laws/CHANGELOG.md
@@ -4,6 +4,12 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 2.3 -- 2021-12-07
+
+### Added
+
+* `Laws` newtype for extending the existing laws-based testing.
+
 ## 2.2 -- 2021-12-01
 
 ### Added

--- a/plutus-laws/CHANGELOG.md
+++ b/plutus-laws/CHANGELOG.md
@@ -4,11 +4,12 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
-## 2.3 -- 2021-12-07
+## 2.3 -- 2021-12-08
 
 ### Added
 
 * `Laws` newtype for extending the existing laws-based testing.
+* `laws` and `lawsWith` for running custom `Laws`-based tests.
 
 ## 2.2 -- 2021-12-01
 

--- a/plutus-laws/README.md
+++ b/plutus-laws/README.md
@@ -32,7 +32,7 @@ specification of generators and shrinkers to use while testing the laws.
 
 As this wraps `tasty-quickcheck`, we also support any options that
 `tasty-quickcheck` supports, such as for controlling how many tests get run.
-Lasty, we supply some helpers for writing your own laws and tests.
+Lastly, we supply some helpers for writing your own laws and tests.
 
 ## What are the goals of this project?
 

--- a/plutus-laws/plutus-laws.cabal
+++ b/plutus-laws/plutus-laws.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-laws
-version:            2.2
+version:            2.3
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -53,6 +53,7 @@ library
     , aeson             ^>=1.5.6.0
     , aeson-pretty      ^>=0.8.8
     , bytestring        ^>=0.10.12.0
+    , invariant         ^>=0.5.3
     , plutus-tx
     , pretty            ^>=1.1.3.6
     , pretty-show       ^>=1.10

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -117,7 +117,7 @@ test-suite laws
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
   build-depends:
-    , plutus-laws       ^>=2.2
+    , plutus-laws       ^>=2.3
     , tasty-quickcheck  ^>=0.10.1.2
 
   hs-source-dirs: test/laws


### PR DESCRIPTION
This defines some helpers (and an opaque newtype) allowing client modules to easily add their own laws for testing.