### PR TITLE
Change `instance Arbitrary Value`

### DIFF
--- a/plutus-deriving/plutus-deriving.cabal
+++ b/plutus-deriving/plutus-deriving.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-deriving
-version:            1.0
+version:            1.1
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -66,7 +66,7 @@ library testlib
     , plutus-deriving
     , plutus-tx
     , QuickCheck                   ^>=2.14.2
-    , quickcheck-plutus-instances  ^>=1.2
+    , quickcheck-plutus-instances  ^>=1.3
 
   hs-source-dirs:  test
 

--- a/quickcheck-plutus-instances/CHANGELOG.md
+++ b/quickcheck-plutus-instances/CHANGELOG.md
@@ -4,6 +4,17 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 1.3 -- 2021-12-09
+
+### Added
+
+* `uniqueListOf` for generating UniqueList of the given length
+
+### Changed
+
+* Instance Arbitrary for `Value` limited by number of AssetClasses.
+  Now the number equals to `(log2 testSize)^2`
+
 ## 1.2 -- 2021-11-23
 
 ### Added

--- a/quickcheck-plutus-instances/quickcheck-plutus-instances.cabal
+++ b/quickcheck-plutus-instances/quickcheck-plutus-instances.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               quickcheck-plutus-instances
-version:            1.2
+version:            1.3
 extra-source-files: CHANGELOG.md
 
 common lang

--- a/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
+++ b/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
@@ -462,10 +462,10 @@ instance Arbitrary Value where
     num <- log2 <$> getSize
     UniqueList css <- uniqueListOf num
     lst <- forM css $ \cs -> do
-        UniqueList tns <- uniqueListOf num
-        pure $ (cs, AssocMap.fromList tns)
+      UniqueList tns <- uniqueListOf num
+      pure $ (cs, AssocMap.fromList tns)
     pure . Value . AssocMap.fromList $ lst
-  shrink (Value mp) = 
+  shrink (Value mp) =
     fmap (Value . unUniqueKeys) . liftShrink shrinkAsUniqueKeys . UniqueKeys $ mp
     where
       shrinkAsUniqueKeys ::
@@ -686,5 +686,5 @@ shrinkNonNegative i = do
 -- Integer part of logarithm base 2
 log2 :: Int -> Int
 log2 n
-  | n <=1 = 0
-  | otherwise = 1 + log2 (n `div` 2) 
+  | n <= 1 = 0
+  | otherwise = 1 + log2 (n `div` 2)

--- a/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
+++ b/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
@@ -463,7 +463,8 @@ instance Arbitrary Value where
     UniqueList css <- uniqueListOf num
     lst <- forM css $ \cs -> do
       UniqueList tns <- uniqueListOf num
-      pure $ (cs, AssocMap.fromList tns)
+      lst' <- forM tns $ \tn -> (tn,) <$> arbitrary
+      pure (cs, AssocMap.fromList lst')
     pure . Value . AssocMap.fromList $ lst
   shrink (Value mp) =
     fmap (Value . unUniqueKeys) . liftShrink shrinkAsUniqueKeys . UniqueKeys $ mp

--- a/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
+++ b/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Instances.hs
@@ -23,7 +23,7 @@
 -}
 module Test.QuickCheck.Plutus.Instances () where
 
-import Control.Monad (guard)
+import Control.Monad (forM, guard)
 import Data.ByteString (ByteString)
 import Data.Kind (Type)
 import Data.Maybe (maybeToList)
@@ -86,6 +86,7 @@ import Test.QuickCheck.Function (Function (function), functionMap)
 import Test.QuickCheck.Gen (
   Gen,
   chooseInt,
+  getSize,
   oneof,
   scale,
   sized,
@@ -94,7 +95,11 @@ import Test.QuickCheck.Gen (
  )
 import Test.QuickCheck.Instances.Text ()
 import Test.QuickCheck.Modifiers (NonNegative (NonNegative))
-import Test.QuickCheck.Plutus.Modifiers (UniqueKeys (UniqueKeys))
+import Test.QuickCheck.Plutus.Modifiers (
+  UniqueKeys (UniqueKeys, unUniqueKeys),
+  UniqueList (UniqueList),
+  uniqueListOf,
+ )
 
 -- | @since 1.0
 instance Arbitrary BuiltinByteString where
@@ -452,10 +457,21 @@ instance (Function k, Function v) => Function (AssocMap.Map k v) where
   function = functionMap AssocMap.toList AssocMap.fromList
 
 -- | @since 1.1
-deriving via
-  (UniqueKeys CurrencySymbol (UniqueKeys TokenName Integer))
-  instance
-    Arbitrary Value
+instance Arbitrary Value where
+  arbitrary = do
+    num <- log2 <$> getSize
+    UniqueList css <- uniqueListOf num
+    lst <- forM css $ \cs -> do
+        UniqueList tns <- uniqueListOf num
+        pure $ (cs, AssocMap.fromList tns)
+    pure . Value . AssocMap.fromList $ lst
+  shrink (Value mp) = 
+    fmap (Value . unUniqueKeys) . liftShrink shrinkAsUniqueKeys . UniqueKeys $ mp
+    where
+      shrinkAsUniqueKeys ::
+        AssocMap.Map TokenName Integer ->
+        [AssocMap.Map TokenName Integer]
+      shrinkAsUniqueKeys = fmap unUniqueKeys . shrink . UniqueKeys
 
 -- | @since 1.1
 deriving via
@@ -666,3 +682,9 @@ shrinkNonNegative :: Integer -> [Integer]
 shrinkNonNegative i = do
   NonNegative i' <- shrink . NonNegative $ i
   pure i'
+
+-- Integer part of logarithm base 2
+log2 :: Int -> Int
+log2 n
+  | n <=1 = 0
+  | otherwise = 1 + log2 (n `div` 2) 

--- a/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Modifiers.hs
+++ b/quickcheck-plutus-instances/src/Test/QuickCheck/Plutus/Modifiers.hs
@@ -63,7 +63,7 @@ newtype UniqueList (a :: Type) = UniqueList [a]
 
 -- | @since 1.1
 instance (Arbitrary a, PlutusTx.Ord a) => Arbitrary (UniqueList a) where
-  arbitrary = sized $ \ size -> chooseInt (0, size) >>= uniqueListOf
+  arbitrary = sized $ \size -> chooseInt (0, size) >>= uniqueListOf
   shrink (UniqueList xs) = UniqueList <$> (filter isSorted . shrink $ xs)
 
 -- | @since 1.1
@@ -77,8 +77,7 @@ instance (Function a) => Function (UniqueList a) where
 
  @since 1.1
 -}
-newtype UniqueKeys (k :: Type) (v :: Type) =
-  UniqueKeys
+newtype UniqueKeys (k :: Type) (v :: Type) = UniqueKeys
   { -- | @since 1.3
     unUniqueKeys :: AssocMap.Map k v
   }
@@ -218,7 +217,7 @@ instance (Function a) => Function (NonZero a) where
       into (NonZero x) = x
 
 {- | Generates a UniqueList of the given length.
- 
+
  @since 1.3
 -}
 uniqueListOf ::


### PR DESCRIPTION
```
Benchmark bench: RUNNING...
"Derived instance : average length with testSize 100 is 2467"
"Limited instance : average length with testSize 100 is 35"

benchmarking Arbitrary instance derived via UniqueKey
time                 15.20 s    (13.78 s .. 16.21 s)
                     0.999 R²   (0.997 R² .. 1.000 R²)
mean                 15.47 s    (15.20 s .. 15.67 s)
std dev              281.1 ms   (165.5 ms .. 391.0 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Limited in size Arbitrary instance
time                 241.5 ms   (231.2 ms .. 254.9 ms)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 236.9 ms   (234.9 ms .. 240.4 ms)
std dev              3.408 ms   (1.774 ms .. 4.680 ms)
variance introduced by outliers: 16% (moderately inflated)

Benchmark bench: FINISH
```