### PR TITLE
Added addressValueOptions to Plutus.Contract.Test.Extra.

### DIFF
--- a/plutus-extra/CHANGELOG.md
+++ b/plutus-extra/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
+## 3.2 -- 2021-12-14
+
+### Added
+
+- Added `addressValueOptions` to make construction of
+  emulator traces involving data easier.
+
 ## 3.1 -- 2021-12-13
 
 ### Added

--- a/plutus-extra/plutus-extra.cabal
+++ b/plutus-extra/plutus-extra.cabal
@@ -85,6 +85,7 @@ library
     , ansi-terminal      ^>=0.11
     , deepseq            ^>=1.4.4.0
     , containers         ^>=0.6.2
+    , data-default-class
     , foldl              ^>=1.4.12
     , freer-simple       ^>=1.2.1.1
     , lens               ^>=4.19.2


### PR DESCRIPTION
addressValueOptions is a function that creates an EmulatorConfig that makes it easier to create emulator traces that start with data and values at (a) specific validator(s).

An example usage is

```
emuConfig :: EmulatorConfig
emuConfig =
  let val = lovelaceValueOf 100_000_000
   in addressValueOptions
        [ (ownerPkh, v)
        , (user1Pkh, v)
        , (user2Pkh, v)
        ]
        [ (valHash, validatorVal1, datum1)
        , (valHash, validatorVal2, datum2)
        ]

validatorVal1 :: Value
validatorVal1 = Value.singleton "abcd" "State Token 1" 1

validatorVal2 :: Value
validatorVal2 = Value.singleton "abcd" "State Token 2" 1

test1 :: TestTree
test1 = checkPredicateOptions
  (defaultCheckOptions & emulatorConfig .~ emuConfig)
  "State Token Test"
  (assertDone contract1 (walletInstanceTag ownerWallet) (const True) "Test #1")
  trace1
```