### PR TITLE
Optimize NatRatio, add script size 'pins'

### DIFF
--- a/cabal-haskell.nix.project
+++ b/cabal-haskell.nix.project
@@ -32,6 +32,11 @@ source-repository-package
     web-ghc
   tag: 404af7ac3e27ebcb218c05f79d9a70ca966407c9
 
+source-repository-package
+  type: git
+  location: https://github.com/nomeata/tasty-expected-failure.git
+  tag: 33b71e694b954e35c05859fff3ca886d8cfe5bfe
+
 -- The following sections are copied from the 'plutus' repository cabal.project at the revision
 -- given above.
 -- This is necessary because the  plutus' libraries depend on a number of other libraries which are

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
               ps.quickcheck-dynamic
               ps.Win32-network
               ps.word-array
+              ps.tasty-expected-failure
             ];
           };
           sha256map = {
@@ -123,6 +124,8 @@
               = "Hesb5GXSx0IwKSIi42ofisVELcQNX6lwHcoZcbaDiqc=";
             "https://github.com/input-output-hk/goblins"."cde90a2b27f79187ca8310b6549331e59595e7ba"
               = "z9ut0y6umDIjJIRjz9KSvKgotuw06/S8QDwOtVdGiJ0=";
+            "https://github.com/nomeata/tasty-expected-failure.git"."33b71e694b954e35c05859fff3ca886d8cfe5bfe"
+              = "C/IWktTILklfPEAht/RE4IC8to6MrvrLmmbqgWsJlIM=";
           };
         };
     in

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -130,7 +130,10 @@ test-suite size
   import:         test-lang
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
-  other-modules:  Rational
+  other-modules:
+    NatRatio
+    Rational
+
   build-depends:
     , plutus-ledger-api
     , plutus-size-check  ^>=1.1

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -130,6 +130,7 @@ test-suite size
   import:         test-lang
   type:           exitcode-stdio-1.0
   main-is:        Main.hs
+  other-modules:  Rational
   build-depends:
     , plutus-ledger-api
     , plutus-size-check  ^>=1.1

--- a/plutus-numeric/plutus-numeric.cabal
+++ b/plutus-numeric/plutus-numeric.cabal
@@ -149,3 +149,16 @@ test-suite rational-compare-size
     , plutus-tx-plugin
 
   hs-source-dirs: test/rational-compare-size
+
+test-suite natratio-compare-size
+  import:         test-lang
+  type:           exitcode-stdio-1.0
+  main-is:        Main.hs
+  build-depends:
+    , plutus-ledger-api
+    , plutus-size-check
+    , plutus-tx
+    , plutus-tx-plugin
+    , tasty-expected-failure  ^>=0.12.3
+
+  hs-source-dirs: test/natratio-compare-size

--- a/plutus-numeric/src/PlutusTx/Numeric/Extra.hs
+++ b/plutus-numeric/src/PlutusTx/Numeric/Extra.hs
@@ -41,7 +41,11 @@ import PlutusTx.Natural.Internal (Natural (Natural))
 import PlutusTx.Prelude hiding (divMod, even, (%))
 import PlutusTx.Ratio qualified as Ratio
 import PlutusTx.Rational qualified as Rational
-import PlutusTx.Rational.Internal (rDiv, rPowInteger)
+import PlutusTx.Rational.Internal (
+  Rational (Rational),
+  rDiv,
+  rPowInteger,
+ )
 import Prelude ()
 
 {- | Raise by a 'Natural' power.
@@ -326,6 +330,11 @@ instance IntegralDomain Rational.Rational NatRatio where
     | otherwise = Just . NatRatio $ x
   {-# INLINEABLE addExtend #-}
   addExtend (NatRatio r) = r
+  {-# INLINEABLE signum #-}
+  signum (Rational n _)
+    | n < zero = Rational (negate one) one
+    | n == zero = zero
+    | otherwise = one
 
 {- | Non-operator version of '^-'.
 

--- a/plutus-numeric/src/PlutusTx/Numeric/Extra.hs
+++ b/plutus-numeric/src/PlutusTx/Numeric/Extra.hs
@@ -36,12 +36,12 @@ module PlutusTx.Numeric.Extra (
 ) where
 
 import Data.Kind (Type)
-import PlutusTx.NatRatio.Internal (NatRatio (NatRatio))
+import PlutusTx.NatRatio.Internal (NatRatio (NatRatio), nrMonus)
 import PlutusTx.Natural.Internal (Natural (Natural))
 import PlutusTx.Prelude hiding (divMod, even, (%))
 import PlutusTx.Ratio qualified as Ratio
 import PlutusTx.Rational qualified as Rational
-import PlutusTx.Rational.Internal ((%))
+import PlutusTx.Rational.Internal (rDiv, rPowInteger)
 import Prelude ()
 
 {- | Raise by a 'Natural' power.
@@ -120,9 +120,13 @@ instance AdditiveHemigroup Natural where
 -}
 instance AdditiveHemigroup NatRatio where
   {-# INLINEABLE (^-) #-}
+  nr ^- nr' = nrMonus nr nr'
+
+{-
   NatRatio r1 ^- NatRatio r2
     | r1 < r2 = zero
     | otherwise = NatRatio $ r1 - r2
+-}
 
 {- | We define the combination of an 'AdditiveHemigroup' and a
  'MultiplicativeMonoid' as a \'hemiring\'. This is designed to be symmetric
@@ -228,12 +232,11 @@ infixr 8 `powInteger`
 -- | @since 1.0
 instance MultiplicativeGroup Rational.Rational where
   {-# INLINEABLE (/) #-}
-  x / y = x * reciprocal y
+  (/) = rDiv
   {-# INLINEABLE reciprocal #-}
-  reciprocal x =
-    let n = Rational.numerator x
-        m = Rational.denominator x
-     in m % n
+  reciprocal = Rational.recip
+  {-# INLINEABLE powInteger #-}
+  powInteger = rPowInteger
 
 -- | @since 1.0
 instance MultiplicativeGroup NatRatio where
@@ -241,6 +244,8 @@ instance MultiplicativeGroup NatRatio where
   NatRatio r / NatRatio r' = NatRatio (r / r')
   {-# INLINEABLE reciprocal #-}
   reciprocal (NatRatio r) = NatRatio . reciprocal $ r
+  {-# INLINEABLE powInteger #-}
+  powInteger (NatRatio r) = NatRatio . powInteger r
 
 -- | @since 1.0
 type Field a = (AdditiveGroup a, MultiplicativeGroup a)

--- a/plutus-numeric/src/PlutusTx/Rational/Internal.hs
+++ b/plutus-numeric/src/PlutusTx/Rational/Internal.hs
@@ -191,7 +191,7 @@ instance FromData Rational where
 instance UnsafeFromData Rational where
   {-# INLINEABLE unsafeFromBuiltinData #-}
   unsafeFromBuiltinData dat = case unsafeFromBuiltinData dat of
-    (n, d) -> if d == zero then error () else n % d
+    (n, d) -> n % d
 
 -- | @since 4.0
 instance ToJSON Rational where

--- a/plutus-numeric/test/natratio-compare-size/Main.hs
+++ b/plutus-numeric/test/natratio-compare-size/Main.hs
@@ -4,6 +4,11 @@ module Main (main) where
 
 import Plutus.V1.Ledger.Scripts (fromCompiledCode)
 import PlutusTx.Code (CompiledCode)
+import PlutusTx.IsData.Class (
+  fromBuiltinData,
+  toBuiltinData,
+  unsafeFromBuiltinData,
+ )
 import PlutusTx.NatRatio (NatRatio)
 import PlutusTx.NatRatio qualified as NatRatio
 import PlutusTx.Natural (Natural)
@@ -56,6 +61,21 @@ main =
         , fitsUnder "/" (fromCompiledCode nrDiv) (fromCompiledCode rDiv)
         , fitsUnder "reciprocal" (fromCompiledCode nrRecip) (fromCompiledCode rRecip)
         , fitsUnder "powInteger" (fromCompiledCode nrPowInteger) (fromCompiledCode rPowInteger)
+        ]
+    , testGroup
+        "Serialization"
+        [ fitsUnder
+            "toBuiltinData"
+            (fromCompiledCode nrToBuiltinData)
+            (fromCompiledCode rToBuiltinData)
+        , expectFailBecause "extra checks are required"
+            . fitsUnder "fromBuiltinData" (fromCompiledCode nrFromBuiltinData)
+            . fromCompiledCode
+            $ rFromBuiltinData
+        , fitsUnder
+            "unsafeFromBuiltinData"
+            (fromCompiledCode nrUnsafeFromBuiltinData)
+            (fromCompiledCode rUnsafeFromBuiltinData)
         ]
     , testGroup
         "Other"
@@ -157,6 +177,15 @@ nrTruncate = $$(compile [||NatRatio.truncate||])
 nrProperFraction :: CompiledCode (NatRatio -> (Natural, NatRatio))
 nrProperFraction = $$(compile [||NatRatio.properFraction||])
 
+nrToBuiltinData :: CompiledCode (NatRatio -> Plutus.BuiltinData)
+nrToBuiltinData = $$(compile [||toBuiltinData||])
+
+nrFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Plutus.Maybe NatRatio)
+nrFromBuiltinData = $$(compile [||fromBuiltinData||])
+
+nrUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> NatRatio)
+nrUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])
+
 rEq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
 rEq = $$(compile [||(Plutus.==)||])
 
@@ -225,3 +254,12 @@ rTruncate = $$(compile [||Rational.truncate||])
 
 rProperFraction :: CompiledCode (Rational -> (Integer, Rational))
 rProperFraction = $$(compile [||Rational.properFraction||])
+
+rToBuiltinData :: CompiledCode (Rational -> Plutus.BuiltinData)
+rToBuiltinData = $$(compile [||toBuiltinData||])
+
+rFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Plutus.Maybe Rational)
+rFromBuiltinData = $$(compile [||fromBuiltinData||])
+
+rUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Rational)
+rUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])

--- a/plutus-numeric/test/natratio-compare-size/Main.hs
+++ b/plutus-numeric/test/natratio-compare-size/Main.hs
@@ -14,6 +14,7 @@ import PlutusTx.NatRatio qualified as NatRatio
 import PlutusTx.Natural (Natural)
 import PlutusTx.Numeric.Extra (
   powInteger,
+  powNat,
   reciprocal,
   (/),
   (^-),
@@ -60,6 +61,7 @@ main =
         , fitsUnder "one" (fromCompiledCode nrOne) (fromCompiledCode rOne)
         , fitsUnder "/" (fromCompiledCode nrDiv) (fromCompiledCode rDiv)
         , fitsUnder "reciprocal" (fromCompiledCode nrRecip) (fromCompiledCode rRecip)
+        , fitsUnder "powNat" (fromCompiledCode nrPowNat) (fromCompiledCode rPowNat)
         , fitsUnder "powInteger" (fromCompiledCode nrPowInteger) (fromCompiledCode rPowInteger)
         ]
     , testGroup
@@ -186,6 +188,9 @@ nrFromBuiltinData = $$(compile [||fromBuiltinData||])
 nrUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> NatRatio)
 nrUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])
 
+nrPowNat :: CompiledCode (NatRatio -> Natural -> NatRatio)
+nrPowNat = $$(compile [||powNat||])
+
 rEq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
 rEq = $$(compile [||(Plutus.==)||])
 
@@ -263,3 +268,6 @@ rFromBuiltinData = $$(compile [||fromBuiltinData||])
 
 rUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Rational)
 rUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])
+
+rPowNat :: CompiledCode (Rational -> Natural -> Rational)
+rPowNat = $$(compile [||powNat||])

--- a/plutus-numeric/test/natratio-compare-size/Main.hs
+++ b/plutus-numeric/test/natratio-compare-size/Main.hs
@@ -1,0 +1,227 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main (main) where
+
+import Plutus.V1.Ledger.Scripts (fromCompiledCode)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.NatRatio (NatRatio)
+import PlutusTx.NatRatio qualified as NatRatio
+import PlutusTx.Natural (Natural)
+import PlutusTx.Numeric.Extra (
+  powInteger,
+  reciprocal,
+  (/),
+  (^-),
+ )
+import PlutusTx.Prelude qualified as Plutus
+import PlutusTx.Rational (Rational)
+import PlutusTx.Rational qualified as Rational
+import PlutusTx.TH (compile)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
+import Test.Tasty.Plutus.Size (fitsUnder)
+import Prelude hiding (Rational, (/))
+
+main :: IO ()
+main =
+  defaultMain . testGroup "NatRatio vs Rational" $
+    [ testGroup
+        "Eq"
+        [ fitsUnder "==" (fromCompiledCode nrEq) (fromCompiledCode rEq)
+        , fitsUnder "/=" (fromCompiledCode nrNeq) (fromCompiledCode rNeq)
+        ]
+    , testGroup
+        "Ord"
+        [ fitsUnder "compare" (fromCompiledCode nrCompare) (fromCompiledCode rCompare)
+        , fitsUnder "<=" (fromCompiledCode nrLE) (fromCompiledCode rLE)
+        , fitsUnder ">=" (fromCompiledCode nrGE) (fromCompiledCode rGE)
+        , fitsUnder "<" (fromCompiledCode nrLT) (fromCompiledCode rLT)
+        , fitsUnder ">" (fromCompiledCode nrGT) (fromCompiledCode rGT)
+        , fitsUnder "min" (fromCompiledCode nrMin) (fromCompiledCode rMin)
+        , fitsUnder "max" (fromCompiledCode nrMax) (fromCompiledCode rMax)
+        ]
+    , testGroup
+        "Additive"
+        [ fitsUnder "+" (fromCompiledCode nrPlus) (fromCompiledCode rPlus)
+        , fitsUnder "zero" (fromCompiledCode nrZero) (fromCompiledCode rZero)
+        , expectFailBecause "monus is trickier"
+            . fitsUnder "^- vs -" (fromCompiledCode nrMonus)
+            . fromCompiledCode
+            $ rMinus
+        ]
+    , testGroup
+        "Multiplicative"
+        [ fitsUnder "*" (fromCompiledCode nrTimes) (fromCompiledCode rTimes)
+        , fitsUnder "one" (fromCompiledCode nrOne) (fromCompiledCode rOne)
+        , fitsUnder "/" (fromCompiledCode nrDiv) (fromCompiledCode rDiv)
+        , fitsUnder "reciprocal" (fromCompiledCode nrRecip) (fromCompiledCode rRecip)
+        , fitsUnder "powInteger" (fromCompiledCode nrPowInteger) (fromCompiledCode rPowInteger)
+        ]
+    , testGroup
+        "Other"
+        [ fitsUnder
+            "whole number conversion"
+            (fromCompiledCode nrFromNatural)
+            (fromCompiledCode rFromInteger)
+        , fitsUnder
+            "numerator"
+            (fromCompiledCode nrNumerator)
+            (fromCompiledCode rNumerator)
+        , fitsUnder
+            "denominator"
+            (fromCompiledCode nrDenominator)
+            (fromCompiledCode rNumerator)
+        , fitsUnder
+            "round"
+            (fromCompiledCode nrRound)
+            (fromCompiledCode rRound)
+        , fitsUnder
+            "truncate"
+            (fromCompiledCode nrTruncate)
+            (fromCompiledCode rTruncate)
+        , fitsUnder
+            "properFraction"
+            (fromCompiledCode nrProperFraction)
+            (fromCompiledCode rProperFraction)
+        ]
+    ]
+
+-- Helpers
+
+nrEq :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrEq = $$(compile [||(Plutus.==)||])
+
+nrNeq :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrNeq = $$(compile [||(Plutus.==)||])
+
+nrCompare :: CompiledCode (NatRatio -> NatRatio -> Plutus.Ordering)
+nrCompare = $$(compile [||Plutus.compare||])
+
+nrLE :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrLE = $$(compile [||(Plutus.<=)||])
+
+nrGE :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrGE = $$(compile [||(Plutus.>=)||])
+
+nrLT :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrLT = $$(compile [||(Plutus.<)||])
+
+nrGT :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrGT = $$(compile [||(Plutus.>)||])
+
+nrMin :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMin = $$(compile [||Plutus.min||])
+
+nrMax :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMax = $$(compile [||Plutus.max||])
+
+nrPlus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrPlus = $$(compile [||(Plutus.+)||])
+
+nrZero :: CompiledCode NatRatio
+nrZero = $$(compile [||Plutus.zero||])
+
+nrMonus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMonus = $$(compile [||(^-)||])
+
+nrTimes :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrTimes = $$(compile [||(Plutus.*)||])
+
+nrOne :: CompiledCode NatRatio
+nrOne = $$(compile [||Plutus.one||])
+
+nrDiv :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrDiv = $$(compile [||(/)||])
+
+nrRecip :: CompiledCode (NatRatio -> NatRatio)
+nrRecip = $$(compile [||reciprocal||])
+
+nrPowInteger :: CompiledCode (NatRatio -> Plutus.Integer -> NatRatio)
+nrPowInteger = $$(compile [||powInteger||])
+
+nrFromNatural :: CompiledCode (Natural -> NatRatio)
+nrFromNatural = $$(compile [||NatRatio.fromNatural||])
+
+nrNumerator :: CompiledCode (NatRatio -> Natural)
+nrNumerator = $$(compile [||NatRatio.numerator||])
+
+nrDenominator :: CompiledCode (NatRatio -> Natural)
+nrDenominator = $$(compile [||NatRatio.denominator||])
+
+nrRound :: CompiledCode (NatRatio -> Natural)
+nrRound = $$(compile [||NatRatio.round||])
+
+nrTruncate :: CompiledCode (NatRatio -> Natural)
+nrTruncate = $$(compile [||NatRatio.truncate||])
+
+nrProperFraction :: CompiledCode (NatRatio -> (Natural, NatRatio))
+nrProperFraction = $$(compile [||NatRatio.properFraction||])
+
+rEq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rEq = $$(compile [||(Plutus.==)||])
+
+rNeq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rNeq = $$(compile [||(Plutus.==)||])
+
+rCompare :: CompiledCode (Rational -> Rational -> Plutus.Ordering)
+rCompare = $$(compile [||Plutus.compare||])
+
+rLE :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rLE = $$(compile [||(Plutus.<=)||])
+
+rGE :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rGE = $$(compile [||(Plutus.>=)||])
+
+rLT :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rLT = $$(compile [||(Plutus.<)||])
+
+rGT :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rGT = $$(compile [||(Plutus.>)||])
+
+rMin :: CompiledCode (Rational -> Rational -> Rational)
+rMin = $$(compile [||Plutus.min||])
+
+rMax :: CompiledCode (Rational -> Rational -> Rational)
+rMax = $$(compile [||Plutus.max||])
+
+rPlus :: CompiledCode (Rational -> Rational -> Rational)
+rPlus = $$(compile [||(Plutus.+)||])
+
+rZero :: CompiledCode Rational
+rZero = $$(compile [||Plutus.zero||])
+
+rMinus :: CompiledCode (Rational -> Rational -> Rational)
+rMinus = $$(compile [||(Plutus.-)||])
+
+rTimes :: CompiledCode (Rational -> Rational -> Rational)
+rTimes = $$(compile [||(Plutus.*)||])
+
+rOne :: CompiledCode Rational
+rOne = $$(compile [||Plutus.one||])
+
+rDiv :: CompiledCode (Rational -> Rational -> Rational)
+rDiv = $$(compile [||(/)||])
+
+rRecip :: CompiledCode (Rational -> Rational)
+rRecip = $$(compile [||reciprocal||])
+
+rPowInteger :: CompiledCode (Rational -> Plutus.Integer -> Rational)
+rPowInteger = $$(compile [||powInteger||])
+
+rFromInteger :: CompiledCode (Plutus.Integer -> Rational)
+rFromInteger = $$(compile [||Rational.fromInteger||])
+
+rNumerator :: CompiledCode (Rational -> Integer)
+rNumerator = $$(compile [||Rational.numerator||])
+
+rDenominator :: CompiledCode (Rational -> Integer)
+rDenominator = $$(compile [||Rational.denominator||])
+
+rRound :: CompiledCode (Rational -> Integer)
+rRound = $$(compile [||Rational.round||])
+
+rTruncate :: CompiledCode (Rational -> Integer)
+rTruncate = $$(compile [||Rational.truncate||])
+
+rProperFraction :: CompiledCode (Rational -> (Integer, Rational))
+rProperFraction = $$(compile [||Rational.properFraction||])

--- a/plutus-numeric/test/size/Main.hs
+++ b/plutus-numeric/test/size/Main.hs
@@ -2,6 +2,7 @@
 
 module Main (main) where
 
+import NatRatio qualified
 import Plutus.V1.Ledger.Scripts (fromCompiledCode)
 import PlutusTx.Code (CompiledCode)
 import PlutusTx.IsData.Class (
@@ -9,20 +10,16 @@ import PlutusTx.IsData.Class (
   toBuiltinData,
   unsafeFromBuiltinData,
  )
-import PlutusTx.NatRatio (NatRatio)
 import PlutusTx.Natural (Natural)
 import PlutusTx.Numeric.Extra (
   abs,
   addExtend,
   divMod,
   monus,
-  powInteger,
   powNat,
   projectAbs,
-  reciprocal,
   restrictMay,
   signum,
-  (/),
  )
 import PlutusTx.Prelude (BuiltinData)
 import PlutusTx.Prelude qualified as PTx
@@ -51,23 +48,6 @@ main =
         , fitsOnChain "divMod" . fromCompiledCode $ naturalDivMod
         ]
     , testGroup
-        "NatRatio"
-        [ fitsOnChain "==" . fromCompiledCode $ natRatioEq
-        , fitsOnChain "compare" . fromCompiledCode $ natRatioCompare
-        , fitsOnChain "+" . fromCompiledCode $ natRatioPlus
-        , fitsOnChain "zero" . fromCompiledCode $ natRatioZero
-        , fitsOnChain "*" . fromCompiledCode $ natRatioTimes
-        , fitsOnChain "one" . fromCompiledCode $ natRatioOne
-        , fitsOnChain "fromBuiltinData" . fromCompiledCode $ natRatioFromBuiltinData
-        , fitsOnChain "toBuiltinData" . fromCompiledCode $ natRatioToBuiltinData
-        , fitsOnChain "unsafeFromBuiltinData" . fromCompiledCode $ natRatioUnsafeFromBuiltinData
-        , fitsOnChain "powNat" . fromCompiledCode $ natRatioPowNat
-        , fitsOnChain "monus" . fromCompiledCode $ natRatioMonus
-        , fitsOnChain "/" . fromCompiledCode $ natRatioDivide
-        , fitsOnChain "reciprocal" . fromCompiledCode $ natRatioReciprocal
-        , fitsOnChain "powInteger" . fromCompiledCode $ natRatioPowInteger
-        ]
-    , testGroup
         "Integer"
         [ fitsOnChain "divMod" . fromCompiledCode $ integerDivMod
         , fitsOnChain "abs" . fromCompiledCode $ integerAbs
@@ -77,6 +57,7 @@ main =
         , fitsOnChain "signum" . fromCompiledCode $ integerSignum
         ]
     , testGroup "Rational" Rational.tests
+    , testGroup "NatRatio" NatRatio.tests
     ]
 
 -- Compiled definitions
@@ -119,51 +100,6 @@ naturalMonus = $$(compile [||monus||])
 
 naturalDivMod :: CompiledCode (Natural -> Natural -> (Natural, Natural))
 naturalDivMod = $$(compile [||divMod||])
-
--- NatRatio
-
-natRatioEq :: CompiledCode (NatRatio -> NatRatio -> Bool)
-natRatioEq = $$(compile [||(PTx.==)||])
-
-natRatioCompare :: CompiledCode (NatRatio -> NatRatio -> Ordering)
-natRatioCompare = $$(compile [||PTx.compare||])
-
-natRatioPlus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
-natRatioPlus = $$(compile [||(PTx.+)||])
-
-natRatioZero :: CompiledCode NatRatio
-natRatioZero = $$(compile [||PTx.zero||])
-
-natRatioTimes :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
-natRatioTimes = $$(compile [||(PTx.*)||])
-
-natRatioOne :: CompiledCode NatRatio
-natRatioOne = $$(compile [||PTx.one||])
-
-natRatioFromBuiltinData :: CompiledCode (BuiltinData -> Maybe NatRatio)
-natRatioFromBuiltinData = $$(compile [||fromBuiltinData||])
-
-natRatioToBuiltinData :: CompiledCode (NatRatio -> BuiltinData)
-natRatioToBuiltinData = $$(compile [||toBuiltinData||])
-
-natRatioUnsafeFromBuiltinData :: CompiledCode (BuiltinData -> NatRatio)
-natRatioUnsafeFromBuiltinData =
-  $$(compile [||unsafeFromBuiltinData||])
-
-natRatioPowNat :: CompiledCode (NatRatio -> Natural -> NatRatio)
-natRatioPowNat = $$(compile [||powNat||])
-
-natRatioMonus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
-natRatioMonus = $$(compile [||monus||])
-
-natRatioDivide :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
-natRatioDivide = $$(compile [||(/)||])
-
-natRatioReciprocal :: CompiledCode (NatRatio -> NatRatio)
-natRatioReciprocal = $$(compile [||reciprocal||])
-
-natRatioPowInteger :: CompiledCode (NatRatio -> Integer -> NatRatio)
-natRatioPowInteger = $$(compile [||powInteger||])
 
 -- Integer
 

--- a/plutus-numeric/test/size/Main.hs
+++ b/plutus-numeric/test/size/Main.hs
@@ -26,8 +26,8 @@ import PlutusTx.Numeric.Extra (
  )
 import PlutusTx.Prelude (BuiltinData)
 import PlutusTx.Prelude qualified as PTx
-import PlutusTx.Rational (Rational)
 import PlutusTx.TH (compile)
+import Rational qualified
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.Plutus.Size (fitsOnChain)
 import Prelude hiding (Rational, abs, divMod, signum, (/))
@@ -76,17 +76,7 @@ main =
         , fitsOnChain "restrictMay" . fromCompiledCode $ integerRestrictMay
         , fitsOnChain "signum" . fromCompiledCode $ integerSignum
         ]
-    , testGroup
-        "Rational"
-        [ fitsOnChain "/" . fromCompiledCode $ rationalDivide
-        , fitsOnChain "reciprocal" . fromCompiledCode $ rationalReciprocal
-        , fitsOnChain "powInteger" . fromCompiledCode $ rationalPowInteger
-        , fitsOnChain "abs" . fromCompiledCode $ rationalAbs
-        , fitsOnChain "projectAbs" . fromCompiledCode $ rationalProjectAbs
-        , fitsOnChain "addExtend" . fromCompiledCode $ rationalAddExtend
-        , fitsOnChain "restrictMay" . fromCompiledCode $ rationalRestrictMay
-        , fitsOnChain "signum" . fromCompiledCode $ rationalSignum
-        ]
+    , testGroup "Rational" Rational.tests
     ]
 
 -- Compiled definitions
@@ -194,29 +184,3 @@ integerRestrictMay = $$(compile [||restrictMay||])
 
 integerSignum :: CompiledCode (Integer -> Integer)
 integerSignum = $$(compile [||signum||])
-
--- Rational
-
-rationalDivide :: CompiledCode (Rational -> Rational -> Rational)
-rationalDivide = $$(compile [||(/)||])
-
-rationalReciprocal :: CompiledCode (Rational -> Rational)
-rationalReciprocal = $$(compile [||reciprocal||])
-
-rationalPowInteger :: CompiledCode (Rational -> Integer -> Rational)
-rationalPowInteger = $$(compile [||powInteger||])
-
-rationalAbs :: CompiledCode (Rational -> Rational)
-rationalAbs = $$(compile [||abs||])
-
-rationalProjectAbs :: CompiledCode (Rational -> NatRatio)
-rationalProjectAbs = $$(compile [||projectAbs||])
-
-rationalAddExtend :: CompiledCode (NatRatio -> Rational)
-rationalAddExtend = $$(compile [||addExtend||])
-
-rationalRestrictMay :: CompiledCode (Rational -> Maybe NatRatio)
-rationalRestrictMay = $$(compile [||restrictMay||])
-
-rationalSignum :: CompiledCode (Rational -> Rational)
-rationalSignum = $$(compile [||signum||])

--- a/plutus-numeric/test/size/NatRatio.hs
+++ b/plutus-numeric/test/size/NatRatio.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module NatRatio (tests) where
+
+import Plutus.V1.Ledger.Scripts (fromCompiledCode)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.IsData.Class (
+  fromBuiltinData,
+  toBuiltinData,
+  unsafeFromBuiltinData,
+ )
+import PlutusTx.NatRatio (NatRatio)
+import PlutusTx.NatRatio qualified as NatRatio
+import PlutusTx.Natural (Natural)
+import PlutusTx.Numeric.Extra (
+  powInteger,
+  powNat,
+  reciprocal,
+  (/),
+  (^-),
+ )
+import PlutusTx.Prelude qualified as Plutus
+import PlutusTx.TH (compile)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Plutus.Size (bytes, fitsInto)
+import Prelude hiding (Rational, abs, signum, (/))
+
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "Eq"
+      [ fitsInto "==" [bytes| 72 |] . fromCompiledCode $ nrEq
+      , fitsInto "/=" [bytes| 72 |] . fromCompiledCode $ nrNeq
+      ]
+  , testGroup
+      "Ord"
+      [ fitsInto "compare" [bytes| 109 |] . fromCompiledCode $ nrCompare
+      , fitsInto "<=" [bytes| 62 |] . fromCompiledCode $ nrLE
+      , fitsInto ">=" [bytes| 62 |] . fromCompiledCode $ nrGE
+      , fitsInto "<" [bytes| 62 |] . fromCompiledCode $ nrLT
+      , fitsInto ">" [bytes| 62 |] . fromCompiledCode $ nrGT
+      , fitsInto "min" [bytes| 70 |] . fromCompiledCode $ nrMin
+      , fitsInto "max" [bytes| 70 |] . fromCompiledCode $ nrMax
+      ]
+  , testGroup
+      "AdditiveGroup"
+      [ fitsInto "+" [bytes| 159 |] . fromCompiledCode $ nrPlus
+      , fitsInto "zero" [bytes| 24 |] . fromCompiledCode $ nrZero
+      , fitsInto "^-" [bytes| 183 |] . fromCompiledCode $ nrMonus
+      ]
+  , testGroup
+      "MultiplicativeGroup"
+      [ fitsInto "*" [bytes| 151 |] . fromCompiledCode $ nrTimes
+      , fitsInto "one" [bytes| 24 |] . fromCompiledCode $ nrOne
+      , fitsInto "/" [bytes| 144 |] . fromCompiledCode $ nrDiv
+      , fitsInto "reciprocal" [bytes| 92 |] . fromCompiledCode $ nrRecip
+      , fitsInto "powNat" [bytes| 343 |] . fromCompiledCode $ nrPowNat
+      , fitsInto "powInteger" [bytes| 357 |] . fromCompiledCode $ nrPowInteger
+      ]
+  , testGroup
+      "Serialization"
+      [ fitsInto "toBuiltinData" [bytes| 78 |] . fromCompiledCode $ nrToBuiltinData
+      , fitsInto "fromBuiltinData" [bytes| 413 |] . fromCompiledCode $ nrFromBuiltinData
+      , fitsInto "unsafeFromBuiltinData" [bytes| 263 |] . fromCompiledCode $ nrUnsafeFromBuiltinData
+      ]
+  , testGroup
+      "Other"
+      [ fitsInto "fromNatural" [bytes| 24 |] . fromCompiledCode $ nrFromNatural
+      , fitsInto "numerator" [bytes| 26 |] . fromCompiledCode $ nrNumerator
+      , fitsInto "denominator" [bytes| 26 |] . fromCompiledCode $ nrNumerator
+      , fitsInto "round" [bytes| 342 |] . fromCompiledCode $ nrRound
+      , fitsInto "truncate" [bytes| 30 |] . fromCompiledCode $ nrTruncate
+      , fitsInto "properFraction" [bytes| 57 |] . fromCompiledCode $ nrProperFraction
+      ]
+  ]
+
+-- Compiled code
+
+nrEq :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrEq = $$(compile [||(Plutus.==)||])
+
+nrNeq :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrNeq = $$(compile [||(Plutus.==)||])
+
+nrCompare :: CompiledCode (NatRatio -> NatRatio -> Plutus.Ordering)
+nrCompare = $$(compile [||Plutus.compare||])
+
+nrLE :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrLE = $$(compile [||(Plutus.<=)||])
+
+nrGE :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrGE = $$(compile [||(Plutus.>=)||])
+
+nrLT :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrLT = $$(compile [||(Plutus.<)||])
+
+nrGT :: CompiledCode (NatRatio -> NatRatio -> Plutus.Bool)
+nrGT = $$(compile [||(Plutus.>)||])
+
+nrMin :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMin = $$(compile [||Plutus.min||])
+
+nrMax :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMax = $$(compile [||Plutus.max||])
+
+nrPlus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrPlus = $$(compile [||(Plutus.+)||])
+
+nrZero :: CompiledCode NatRatio
+nrZero = $$(compile [||Plutus.zero||])
+
+nrMonus :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrMonus = $$(compile [||(^-)||])
+
+nrTimes :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrTimes = $$(compile [||(Plutus.*)||])
+
+nrOne :: CompiledCode NatRatio
+nrOne = $$(compile [||Plutus.one||])
+
+nrDiv :: CompiledCode (NatRatio -> NatRatio -> NatRatio)
+nrDiv = $$(compile [||(/)||])
+
+nrRecip :: CompiledCode (NatRatio -> NatRatio)
+nrRecip = $$(compile [||reciprocal||])
+
+nrPowInteger :: CompiledCode (NatRatio -> Plutus.Integer -> NatRatio)
+nrPowInteger = $$(compile [||powInteger||])
+
+nrFromNatural :: CompiledCode (Natural -> NatRatio)
+nrFromNatural = $$(compile [||NatRatio.fromNatural||])
+
+nrNumerator :: CompiledCode (NatRatio -> Natural)
+nrNumerator = $$(compile [||NatRatio.numerator||])
+
+nrDenominator :: CompiledCode (NatRatio -> Natural)
+nrDenominator = $$(compile [||NatRatio.denominator||])
+
+nrRound :: CompiledCode (NatRatio -> Natural)
+nrRound = $$(compile [||NatRatio.round||])
+
+nrTruncate :: CompiledCode (NatRatio -> Natural)
+nrTruncate = $$(compile [||NatRatio.truncate||])
+
+nrProperFraction :: CompiledCode (NatRatio -> (Natural, NatRatio))
+nrProperFraction = $$(compile [||NatRatio.properFraction||])
+
+nrToBuiltinData :: CompiledCode (NatRatio -> Plutus.BuiltinData)
+nrToBuiltinData = $$(compile [||toBuiltinData||])
+
+nrFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Plutus.Maybe NatRatio)
+nrFromBuiltinData = $$(compile [||fromBuiltinData||])
+
+nrUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> NatRatio)
+nrUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])
+
+nrPowNat :: CompiledCode (NatRatio -> Natural -> NatRatio)
+nrPowNat = $$(compile [||powNat||])

--- a/plutus-numeric/test/size/Rational.hs
+++ b/plutus-numeric/test/size/Rational.hs
@@ -11,10 +11,12 @@ import PlutusTx.IsData.Class (
   unsafeFromBuiltinData,
  )
 import PlutusTx.NatRatio (NatRatio)
+import PlutusTx.Natural (Natural)
 import PlutusTx.Numeric.Extra (
   abs,
   addExtend,
   powInteger,
+  powNat,
   projectAbs,
   reciprocal,
   restrictMay,
@@ -59,6 +61,7 @@ tests =
       , fitsInto "one" [bytes| 24 |] . fromCompiledCode $ rOne
       , fitsInto "/" [bytes| 144 |] . fromCompiledCode $ rDiv
       , fitsInto "reciprocal" [bytes| 92 |] . fromCompiledCode $ rRecip
+      , fitsInto "powNat" [bytes| 343 |] . fromCompiledCode $ rPowNat
       , fitsInto "powInteger" [bytes| 357 |] . fromCompiledCode $ rPowInteger
       ]
   , testGroup
@@ -67,7 +70,7 @@ tests =
       , fitsInto "projectAbs" [bytes| 69 |] . fromCompiledCode $ rProjectAbs
       , fitsInto "addExtend" [bytes| 19 |] . fromCompiledCode $ rAddExtend
       , fitsInto "restrictMay" [bytes| 95 |] . fromCompiledCode $ rRestrictMay
-      , fitsInto "signum" [bytes| 238 |] . fromCompiledCode $ rSignum
+      , fitsInto "signum" [bytes| 97 |] . fromCompiledCode $ rSignum
       ]
   , testGroup
       "Serialization"
@@ -183,3 +186,6 @@ rRestrictMay = $$(compile [||restrictMay||])
 
 rSignum :: CompiledCode (Rational -> Rational)
 rSignum = $$(compile [||signum||])
+
+rPowNat :: CompiledCode (Rational -> Natural -> Rational)
+rPowNat = $$(compile [||powNat||])

--- a/plutus-numeric/test/size/Rational.hs
+++ b/plutus-numeric/test/size/Rational.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Rational (tests) where
+
+import Plutus.V1.Ledger.Scripts (fromCompiledCode)
+import PlutusTx.Code (CompiledCode)
+import PlutusTx.IsData.Class (
+  fromBuiltinData,
+  toBuiltinData,
+  unsafeFromBuiltinData,
+ )
+import PlutusTx.NatRatio (NatRatio)
+import PlutusTx.Numeric.Extra (
+  abs,
+  addExtend,
+  powInteger,
+  projectAbs,
+  reciprocal,
+  restrictMay,
+  signum,
+  (/),
+ )
+import PlutusTx.Prelude qualified as Plutus
+import PlutusTx.Rational (Rational)
+import PlutusTx.Rational qualified as Rational
+import PlutusTx.TH (compile)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Plutus.Size (bytes, fitsInto)
+import Prelude hiding (Rational, abs, signum, (/))
+
+tests :: [TestTree]
+tests =
+  [ testGroup
+      "Eq"
+      [ fitsInto "==" [bytes| 72 |] . fromCompiledCode $ rEq
+      , fitsInto "/=" [bytes| 72 |] . fromCompiledCode $ rNeq
+      ]
+  , testGroup
+      "Ord"
+      [ fitsInto "compare" [bytes| 109 |] . fromCompiledCode $ rCompare
+      , fitsInto "<=" [bytes| 62 |] . fromCompiledCode $ rLE
+      , fitsInto ">=" [bytes| 62 |] . fromCompiledCode $ rGE
+      , fitsInto "<" [bytes| 62 |] . fromCompiledCode $ rLT
+      , fitsInto ">" [bytes| 62 |] . fromCompiledCode $ rGT
+      , fitsInto "min" [bytes| 70 |] . fromCompiledCode $ rMin
+      , fitsInto "max" [bytes| 70 |] . fromCompiledCode $ rMax
+      ]
+  , testGroup
+      "AdditiveGroup"
+      [ fitsInto "+" [bytes| 159 |] . fromCompiledCode $ rPlus
+      , fitsInto "zero" [bytes| 24 |] . fromCompiledCode $ rZero
+      , fitsInto "-" [bytes| 159 |] . fromCompiledCode $ rMinus
+      , fitsInto "negate" [bytes| 35 |] . fromCompiledCode $ rNegate
+      ]
+  , testGroup
+      "MultiplicativeGroup"
+      [ fitsInto "*" [bytes| 151 |] . fromCompiledCode $ rTimes
+      , fitsInto "one" [bytes| 24 |] . fromCompiledCode $ rOne
+      , fitsInto "/" [bytes| 144 |] . fromCompiledCode $ rDiv
+      , fitsInto "reciprocal" [bytes| 92 |] . fromCompiledCode $ rRecip
+      , fitsInto "powInteger" [bytes| 357 |] . fromCompiledCode $ rPowInteger
+      ]
+  , testGroup
+      "IntegralDomain"
+      [ fitsInto "abs" [bytes| 69 |] . fromCompiledCode $ rAbs
+      , fitsInto "projectAbs" [bytes| 69 |] . fromCompiledCode $ rProjectAbs
+      , fitsInto "addExtend" [bytes| 19 |] . fromCompiledCode $ rAddExtend
+      , fitsInto "restrictMay" [bytes| 95 |] . fromCompiledCode $ rRestrictMay
+      , fitsInto "signum" [bytes| 238 |] . fromCompiledCode $ rSignum
+      ]
+  , testGroup
+      "Serialization"
+      [ fitsInto "toBuiltinData" [bytes| 78 |] . fromCompiledCode $ rToBuiltinData
+      , fitsInto "fromBuiltinData" [bytes| 398 |] . fromCompiledCode $ rFromBuiltinData
+      , fitsInto "unsafeFromBuiltinData" [bytes| 263 |] . fromCompiledCode $ rUnsafeFromBuiltinData
+      ]
+  , testGroup
+      "Other"
+      [ fitsInto "fromInteger" [bytes| 24 |] . fromCompiledCode $ rFromInteger
+      , fitsInto "numerator" [bytes| 26 |] . fromCompiledCode $ rNumerator
+      , fitsInto "denominator" [bytes| 26 |] . fromCompiledCode $ rNumerator
+      , fitsInto "round" [bytes| 342 |] . fromCompiledCode $ rRound
+      , fitsInto "truncate" [bytes| 30 |] . fromCompiledCode $ rTruncate
+      , fitsInto "properFraction" [bytes| 57 |] . fromCompiledCode $ rProperFraction
+      ]
+  ]
+
+-- Compiled code
+
+rEq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rEq = $$(compile [||(Plutus.==)||])
+
+rNeq :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rNeq = $$(compile [||(Plutus.==)||])
+
+rCompare :: CompiledCode (Rational -> Rational -> Plutus.Ordering)
+rCompare = $$(compile [||Plutus.compare||])
+
+rLE :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rLE = $$(compile [||(Plutus.<=)||])
+
+rGE :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rGE = $$(compile [||(Plutus.>=)||])
+
+rLT :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rLT = $$(compile [||(Plutus.<)||])
+
+rGT :: CompiledCode (Rational -> Rational -> Plutus.Bool)
+rGT = $$(compile [||(Plutus.>)||])
+
+rMin :: CompiledCode (Rational -> Rational -> Rational)
+rMin = $$(compile [||Plutus.min||])
+
+rMax :: CompiledCode (Rational -> Rational -> Rational)
+rMax = $$(compile [||Plutus.max||])
+
+rPlus :: CompiledCode (Rational -> Rational -> Rational)
+rPlus = $$(compile [||(Plutus.+)||])
+
+rZero :: CompiledCode Rational
+rZero = $$(compile [||Plutus.zero||])
+
+rMinus :: CompiledCode (Rational -> Rational -> Rational)
+rMinus = $$(compile [||(Plutus.-)||])
+
+rNegate :: CompiledCode (Rational -> Rational)
+rNegate = $$(compile [||Rational.negate||])
+
+rTimes :: CompiledCode (Rational -> Rational -> Rational)
+rTimes = $$(compile [||(Plutus.*)||])
+
+rOne :: CompiledCode Rational
+rOne = $$(compile [||Plutus.one||])
+
+rDiv :: CompiledCode (Rational -> Rational -> Rational)
+rDiv = $$(compile [||(/)||])
+
+rRecip :: CompiledCode (Rational -> Rational)
+rRecip = $$(compile [||reciprocal||])
+
+rPowInteger :: CompiledCode (Rational -> Plutus.Integer -> Rational)
+rPowInteger = $$(compile [||powInteger||])
+
+rFromInteger :: CompiledCode (Plutus.Integer -> Rational)
+rFromInteger = $$(compile [||Rational.fromInteger||])
+
+rNumerator :: CompiledCode (Rational -> Integer)
+rNumerator = $$(compile [||Rational.numerator||])
+
+rDenominator :: CompiledCode (Rational -> Integer)
+rDenominator = $$(compile [||Rational.denominator||])
+
+rRound :: CompiledCode (Rational -> Integer)
+rRound = $$(compile [||Rational.round||])
+
+rTruncate :: CompiledCode (Rational -> Integer)
+rTruncate = $$(compile [||Rational.truncate||])
+
+rProperFraction :: CompiledCode (Rational -> (Integer, Rational))
+rProperFraction = $$(compile [||Rational.properFraction||])
+
+rToBuiltinData :: CompiledCode (Rational -> Plutus.BuiltinData)
+rToBuiltinData = $$(compile [||toBuiltinData||])
+
+rFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Plutus.Maybe Rational)
+rFromBuiltinData = $$(compile [||fromBuiltinData||])
+
+rUnsafeFromBuiltinData :: CompiledCode (Plutus.BuiltinData -> Rational)
+rUnsafeFromBuiltinData = $$(compile [||unsafeFromBuiltinData||])
+
+rAbs :: CompiledCode (Rational -> Rational)
+rAbs = $$(compile [||abs||])
+
+rProjectAbs :: CompiledCode (Rational -> NatRatio)
+rProjectAbs = $$(compile [||projectAbs||])
+
+rAddExtend :: CompiledCode (NatRatio -> Rational)
+rAddExtend = $$(compile [||addExtend||])
+
+rRestrictMay :: CompiledCode (Rational -> Maybe NatRatio)
+rRestrictMay = $$(compile [||restrictMay||])
+
+rSignum :: CompiledCode (Rational -> Rational)
+rSignum = $$(compile [||signum||])

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -96,12 +96,12 @@ test-suite properties
   build-depends:
     , base                         ^>=4.14
     , plutus-contract
-    , plutus-extra                 ^>=3.1
+    , plutus-extra                 ^>=4.0
     , plutus-ledger
     , plutus-ledger-api
     , plutus-tx
     , plutus-tx-plugin
-    , quickcheck-plutus-instances  ^>=1.4
+    , quickcheck-plutus-instances  ^>=1.5
     , tasty                        ^>=1.4.1
     , tasty-plutus                 ^>=5.0
     , tasty-quickcheck             ^>=0.10.1.2


### PR DESCRIPTION
This adds performance improvements to `NatRatio` similar to the ones made for `Rational`. We also now have comparison benchmarks between them, as well as 'pins' of sizes for all their core functions, to ensure that they don't increase without us knowing.