### PR TITLE
Add `namedPredicate` function to `Plutus.Contract.Extra`

### DIFF
--- a/plutus-extra/CHANGELOG.md
+++ b/plutus-extra/CHANGELOG.md
@@ -5,6 +5,12 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 4.1 -- 2022-01-07
+
+### Added 
+
+- Plutus.Contract.Test.Extra: `namedPredicate` to give a name to `TracePredicate`
+
 ## 4.0 -- 2021-12-14
 
 ### Added

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -23,7 +23,7 @@ import Control.Foldl qualified as L
 
 import Control.Arrow ((>>>))
 import Control.Lens (at, view, (^.))
-import Control.Monad (unless)
+import Control.Monad (unless, (>=>))
 import Control.Monad.Freer (Eff, Member)
 import Control.Monad.Freer.Error (Error)
 import Control.Monad.Freer.Reader (ask)
@@ -67,6 +67,18 @@ import Wallet.Emulator.Folds (postMapM)
 import Wallet.Emulator.Folds qualified as Folds
 
 --------------------------------------------------------------------------------
+
+{- | Postcompose Kleisli arrow to FoldM.
+
+ @since 4.1
+-}
+postComposeM :: 
+  forall (a :: Type) (b :: Type) (c :: Type) (m :: Type -> Type). 
+  Monad m => 
+  (b -> m c) -> 
+  L.FoldM m a b ->
+  L.FoldM m a c
+postComposeM q (L.FoldM f g h) = L.FoldM f g (h >=> q)
 
 {- | Check that the funds in the wallet have changed by the given amount, exluding fees.
 

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -73,10 +73,10 @@ import Wallet.Emulator.Folds qualified as Folds
 
  @since 4.1
 -}
-postComposeM :: 
-  forall (a :: Type) (b :: Type) (c :: Type) (m :: Type -> Type). 
-  Monad m => 
-  (b -> m c) -> 
+postComposeM ::
+  forall (a :: Type) (b :: Type) (c :: Type) (m :: Type -> Type).
+  Monad m =>
+  (b -> m c) ->
   L.FoldM m a b ->
   L.FoldM m a c
 postComposeM q (L.FoldM f g h) = L.FoldM f g (h >=> q)

--- a/plutus-extra/src/Plutus/Contract/Test/Extra.hs
+++ b/plutus-extra/src/Plutus/Contract/Test/Extra.hs
@@ -5,6 +5,7 @@
  'Plutus.Trace.Emulator.EmulatorTrace' monad.
 -}
 module Plutus.Contract.Test.Extra (
+  namedPredicate,
   walletFundsChangeWithAccumState,
   walletFundsExactChangeWithAccumState,
   valueAtComputedAddress,
@@ -79,6 +80,18 @@ postComposeM ::
   L.FoldM m a b ->
   L.FoldM m a c
 postComposeM q (L.FoldM f g h) = L.FoldM f g (h >=> q)
+
+{- | Give name to a 'TracePredicate'.
+
+ @since 4.1
+-}
+namedPredicate :: String -> TracePredicate -> TracePredicate
+namedPredicate name = postComposeM notify
+  where
+    notify False = False <$ tell message
+    notify b = pure b
+
+    message = "On predicate: " <> viaShow @String @Void name
 
 {- | Check that the funds in the wallet have changed by the given amount, exluding fees.
 


### PR DESCRIPTION
The purpose is to allow giving names to `TracePredicates` without wrapping them in tests groups.

The signature is:
```hs
namedPredicate :: String -> TracePredicate -> TracePredicate
```

Here is the output example when 2 of 4 predicates (under conjunction) failed:
```
My pretty test:                                                  FAIL (0.12s)
        Funds at address ScriptCredential: ... were ...
        On predicate: Validator presents at the expected address
        Funds at address ScriptCredential: ... were ...
        On predicate: Token returns to the validator
        Test failed.
        Emulator log:
        ...
```
So it's still single emulator log for all failed predicates, but all failed predicates mentioned in output.