### PR TITLE
Change `makeIncompleteContexts` to work on any `Semigroup`

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,12 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 7.3 - 2022-02-07
+
+### Changed
+
+* `makeIncompleteContexts` now takes any `Semigroup` instead of a `ContextBuilder`.
+
 ## 7.2 - 2022-02-04
 
 ### Added

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Context.hs
@@ -312,16 +312,19 @@ compileMinting conf cb toks =
 
      > mapM_ (\(ctx,str) -> shouldn'tValidate str input ctx) convertedContexts
 
+     As of 7.3 this works on any `Semigroup` instead of
+     just `ContextBuilder`.
+
  @since 4.1
 -}
 makeIncompleteContexts ::
-  forall (p :: Purpose).
-  [(ContextBuilder p, String)] ->
-  [(ContextBuilder p, String)]
+  forall (s :: Type).
+  (Semigroup s) =>
+  [(s, String)] ->
+  [(s, String)]
 makeIncompleteContexts ctxs = map (first sconcat) ctxs2
   where
-    ctxs1 = removeContext ctxs
-    ctxs2 = mapMaybe nonEmpty1st ctxs1
+    ctxs2 = mapMaybe nonEmpty1st $ removeContext ctxs
     nonEmpty1st :: ([a], b) -> Maybe (NonEmpty a, b)
     nonEmpty1st (xs, y) = (,y) <$> NonEmpty.nonEmpty xs
 


### PR DESCRIPTION
This generalises `makeIncompleteContexts` to work on any `Semigroup`, since the general functionality can be useful in contexts other than just `ContextBuilder`s.