### PR TITLE
Added functions for property tests for traces.

### DIFF
--- a/plutus-extra/CHANGELOG.md
+++ b/plutus-extra/CHANGELOG.md
@@ -4,6 +4,15 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+### 5.2 -- 2022-02-25
+
+### Added
+
+* Functions to create Hedgehog-based property tests for traces:
+  - `checkPredicateGenAll`
+  - `checkPredicateGenAllShow`
+  - `checkPredicateGenAllShows`
+
 ## 5.1 -- 2022-02-04
 
 ### Added

--- a/plutus-extra/plutus-extra.cabal
+++ b/plutus-extra/plutus-extra.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-extra
-version:            5.1
+version:            5.2
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -99,6 +99,7 @@ library
     , either                     ^>=5.0.1
     , foldl                      ^>=1.4.12
     , freer-simple               ^>=1.2.1.1
+    , hedgehog                   ^>=1.0
     , lens                       ^>=4.19.2
     , memory                     ^>=0.16.0
     , plutus-chain-index-core


### PR DESCRIPTION
Added functions that make property tests for emulator traces using Hedgehog. These are far more versatile than `checkPredicateGenOptions` from Plutus.Contract.Test.