### PR TITLE
Named sub-contexts

### DIFF
--- a/plutus-context-builder/CHANGELOG.md
+++ b/plutus-context-builder/CHANGELOG.md
@@ -8,14 +8,21 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ### Added
 
-* `ContextFragment` type, representing the old `ContextBuilder`, but without
-  names; those are still handled by `ContextBuilder` as before.
-* `named` and `deleteNamed` for working with `ContextBuilder` and naming.
+* `ContextFragment` type, representing the old-style `ContextBuilder`, but
+  without names. Names are still handled by `ContextBuilder`.
+* `Naming` type, describing whether we are using named sub-contexts or not.
+* `named`, `deleteNamed`, `unionNamed`, `alterNamed` for working with named sub-contexts.
+* `liftContextFragment` for directly converting a hand-rolled `ContextFragment`
+  into an anonymous `ContextBuilder`.
+* `liftNamedContextFragment` for directly converting a hand-rolled
+  `ContextFragment` into a named `ContextBuilder`.
 
 ### Changed
 
 * `ValidatorUTXO` and `TestUTXO` no longer have data type contexts.
-* `ContextBuilder` now wraps a `Map Text ContextFragment`.
+* `ContextBuilder` can now be anonymous or named; this is tagged using a
+  `Naming`.
+* `ContextBuilder` constructor no longer publically exported.
 * `cbDatums` renamed `cfDatums`, now a field of `ContextFragment`, returns a 
   `Seq`.
 * `cbInputs` renamed `cfInputs`, now a field of `ContextFragment`, returns a
@@ -30,17 +37,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
   `ContextFragment`.
 * `cbValidatorOutputs` renamed `cfValidatorOutputs`, now a field of
   `ContextFragment`.
-* `input`, `output`, `signedWith`, `datum`, `addDatum`, `minting`, 
-  `outToPubKey`, `outToPubKeyWithDatum`, `outTokensToPubKey`,
-  `outTokensToPubKeyWithDatum`, `outLovelaceToPubKey`,
-  `outLovelaceToPubKeyWithDatum`, `outToOtherScript`, 
-  `outTokensToOtherScript`, `inFromPubKeyWithDatum`, `inTokensFromPubKey`, 
-  `inTokensFromPubKeyWithDatum`, `inLovelacyFromPubKey`,
-  `inLovelaceFromPubKeyWithDatum`, `inFromOtherScript`,
-  `inTokensFromOtherScript`, `mintedValue` all no longer 
-  take a name argument, all return `ContextFragment`.
-* `validatorInput`, `validatorOutput`, `outToValidator`, `inFromValidator` now 
-  return a `ContextFragment`.
+* All 'construction helpers' for `ContextBuilder` now return anonymous
+  `ContextFragments`.
 
 ## 1.0 -- 2022-02-04
 

--- a/plutus-context-builder/CHANGELOG.md
+++ b/plutus-context-builder/CHANGELOG.md
@@ -4,6 +4,16 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 2.0 -- 2022-03-09
+
+### Changed
+
+* `ValidatorUTXO` and `TestUTXO` no longer have data type contexts.
+* `ContextBuilder`'s `cbSignatures` now allows duplicate entries for the same
+  key.
+* `ContextBuilder`'s `<>` now keeps all signatures from both 'sides' of the
+  operator.
+
 ## 1.0 -- 2022-02-04
 
 * Initial release.

--- a/plutus-context-builder/CHANGELOG.md
+++ b/plutus-context-builder/CHANGELOG.md
@@ -6,13 +6,41 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## 2.0 -- 2022-03-09
 
+### Added
+
+* `ContextFragment` type, representing the old `ContextBuilder`, but without
+  names; those are still handled by `ContextBuilder` as before.
+* `named` and `deleteNamed` for working with `ContextBuilder` and naming.
+
 ### Changed
 
 * `ValidatorUTXO` and `TestUTXO` no longer have data type contexts.
-* `ContextBuilder`'s `cbSignatures` now allows duplicate entries for the same
-  key.
-* `ContextBuilder`'s `<>` now keeps all signatures from both 'sides' of the
-  operator.
+* `ContextBuilder` now wraps a `Map Text ContextFragment`.
+* `cbDatums` renamed `cfDatums`, now a field of `ContextFragment`, returns a 
+  `Seq`.
+* `cbInputs` renamed `cfInputs`, now a field of `ContextFragment`, returns a
+  `Seq`.
+* `cbMinting` renamed `cfMinting`, now a field of `ContextFragment`, returns a
+  `Seq`.
+* `cbOutputs` renamed `cfOutputs`, now a field of `ContextFragment`, returns a
+  `Seq`.
+* `cbSignatures` renamed `cfSignatures`, now a field of `ContextFragment`,
+  returns a `Seq.
+* `cbValidatorInputs` renamed `cfValidatorInputs`, now a field of
+  `ContextFragment`.
+* `cbValidatorOutputs` renamed `cfValidatorOutputs`, now a field of
+  `ContextFragment`.
+* `input`, `output`, `signedWith`, `datum`, `addDatum`, `minting`, 
+  `outToPubKey`, `outToPubKeyWithDatum`, `outTokensToPubKey`,
+  `outTokensToPubKeyWithDatum`, `outLovelaceToPubKey`,
+  `outLovelaceToPubKeyWithDatum`, `outToOtherScript`, 
+  `outTokensToOtherScript`, `inFromPubKeyWithDatum`, `inTokensFromPubKey`, 
+  `inTokensFromPubKeyWithDatum`, `inLovelacyFromPubKey`,
+  `inLovelaceFromPubKeyWithDatum`, `inFromOtherScript`,
+  `inTokensFromOtherScript`, `mintedValue` all no longer 
+  take a name argument, all return `ContextFragment`.
+* `validatorInput`, `validatorOutput`, `outToValidator`, `inFromValidator` now 
+  return a `ContextFragment`.
 
 ## 1.0 -- 2022-02-04
 

--- a/plutus-context-builder/README.md
+++ b/plutus-context-builder/README.md
@@ -2,45 +2,78 @@
 
 ## What is this?
 
-A utility library for creating `ScriptContext` with `Spending` or `Minting` `ScriptPurpose`. This provides a builder abstraction for assembling ScriptContext, for use in `tasty-plutus`, or somewhere else.
+A utility library for creating `ScriptContext`s with `Spending` or `Minting` 
+`ScriptPurpose`. We provide a builder abstraction for assembling 
+`ScriptContext`s; we use this library in `tasty-plutus`, but provide this 
+functionality for use in other places as well.
 
 ## What can this do?
 
-To create `ScriptContext`, you can use functions like `outToPubKey`, `inFromValidator`, `mintedValue` etc. These functions create named `ContextBuilder` parts, that describe various parts of the transaction from a script point of view.
+We currently support the following:
 
-Once you have a `ContextBuilder`, you can
-* modify parts of it by accessing them by name 
-* build `ScriptContext` using `spendingScriptContext` and `mintingScriptContext` functions
+* Incremental construction of `ScriptContext`s, using a range of helper
+  functionality.
+* The ability to name, and modify, arbitrary sub-contexts if you wish.
+* Low-level 'hooks' allowing definition of precise `ScriptContext` behaviour if
+  required.
+* Construction of `ScriptContext`s for both minting and spending.
 
-## What does 'script point of view' mean?
+## How do I use this?
 
-`ScriptContext` is always passed to one specific _script_ (_validator_ or _mintingpolicy_) for one specific _check_.
+To create a `ScriptContext`, use functions such as `outToPubKey`,
+`inFromValidator`, `mintedValue`, and so on. These functions create anonymous
+`ContextBuilder` parts, which describe various parts of the transaction from a
+script point of view. If you wish, you can use `named` to name anonymous
+`ContextBuilder`s, which can then be combined with other named
+`ContextBuilder`s. We provide a monoidal API for both anonymous and named
+`ContextBuilder`s to assist in this.
 
-Thus any transaction input can be classified as:
-1. input from the _validator_ address, validated in the _check_
-2. input from the _validator_ address, not validated in the _check_
-3. input from the address of any other script
-4. input from the address of a wallet
+Once you have a finished `ContextBuilder`, you can use it to build a
+`ScriptContext` using either `spendingScriptContext` or `mintingScriptContext`.
 
-The same with a transaction output. It can be classified as:
-1. output to the _validator_ address
-2. output to the address of any other script
-3. output to the address of a wallet
+### What does 'script point of view' mean?
 
-Let's look at this classification in a little more detail.
+A `ScriptContext` is always passed to one specific _script_ (which can be a
+_validator_ or a _minting policy_ in our case), for one specific _check_. 
 
-Inputs `3` and `4`, as well as outputs `2` and `3` correspond to `SideUTXO`.
-They can be represented by functions like `...ToPubKey...`, `...FromPubKey...`, `...ToOtherScript...`, `...FromOtherScript...`.
+For a validator, any transaction input can be classified as:
 
-Inputs `2` and outputs `1` correspond to `ValidatorUTXO` and can be represented by functions `inFromValidator` and `outFromValidator`.
+1. Input from the validator address, which is validated in the check;
+1. Input from the validator address, which is **not** validated in the
+   check;
+1. Input from the address of any other script;
+1. Input from the address of a wallet.
 
-Input `1` corresponds to `TestUTXO`. It is not a part of the `ContextBuilder`. You have to provide a `TestUTXO` directly to one of the consumer functions (`spendingScriptContext` or `spendingScriptContextDef`).
-__Note__ `TestUTXO` doesn't make sense in `ScriptContext` with `Minting` purpose.
+We can do the same with its transaction outputs:
 
-If you create a `Minting` context for the _mintingpolicy_, you must also classify inputs and outputs as:
-1. Which only contain tokens controlled by the _mintingpolicy_.
-   Those inputs and outputs have to be represented by functions like `...Tokens...`.
-2. Which don't contain tokens controlled by the _mintingpolicy_.
-   Those inputs and outputs have to be represented by functions without `...Tokens...`.
-3. Which contain tokes controlled as well as not controlled by the _mintingpolicy_.
-   Those inputs and outputs have to be represented as a combination of `1` and `2`
+1. Output to the validator address;
+1. Output to the address of any other script;
+1. Output to the address of a wallet.
+
+Let's examine this classification, and its implications for the library, in more
+detail. Inputs of type 3 and 4, as well as outputs of type 2 and 3, correspond
+to the `SideUTXO` data type, and can be constructed by using `ToPubKey`,
+`FromPubKey`, `ToOtherScript` and `FromOtherScript`, as well as helpers
+operating on these. Inputs of type 2, as well as outputs of type 1, correspond
+to the `ValidatorUTXO` data type, and can be built using the helpers
+`inFromValidator` and `outFromValidator. Lastly, inputs of type 1 correspond to
+the `TestUTXO` data type. Unlike the others, this is not part of the
+`ContextBuilder` abstraction, and needs to be provided directly to one of the
+functions that _consume_ a `ContextBuilder` (namely, `spendingScriptContext`).
+
+For minting policies, we can also classify inputs and outputs in a similar
+way:
+
+1. Those which only contain tokens controlled by the minting policy;
+1. Those which only contain tokens _not_ controlled by the minting policy;
+1. Those which contain both.
+
+Type 1 inputs and outputs are represented with helper functions using the
+`Tokens` type. Type 2 inputs and outputs are represented with helper functions
+_not_ using the `Tokens` type. Type 3 inputs and outputs require use of both.
+Note that `TestUTXO` does not make sense for a `ScriptContext` designed for a
+minting policy.
+
+## What can I do with this?
+
+The code is licensed under Apache 2.0; check the LICENSE.md for details.

--- a/plutus-context-builder/plutus-context-builder.cabal
+++ b/plutus-context-builder/plutus-context-builder.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutus-context-builder
-version:            1.0
+version:            2.0
 extra-source-files: CHANGELOG.md
 
 common lang

--- a/plutus-context-builder/src/Test/Plutus/ContextBuilder.hs
+++ b/plutus-context-builder/src/Test/Plutus/ContextBuilder.hs
@@ -88,6 +88,7 @@ module Test.Plutus.ContextBuilder (
 
 import Data.Kind (Type)
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Ledger.Address (PaymentPubKeyHash (unPaymentPubKeyHash))
 import Ledger.Crypto (PubKeyHash)
@@ -203,7 +204,7 @@ signedWith ::
   Text ->
   PubKeyHash ->
   ContextBuilder p
-signedWith name x = mempty {cbSignatures = Map.singleton name x}
+signedWith name x = mempty {cbSignatures = Map.singleton name . Set.singleton $ x}
 
 {- | Context with one additional datum.
 

--- a/plutus-context-builder/src/Test/Plutus/ContextBuilder/Internal.hs
+++ b/plutus-context-builder/src/Test/Plutus/ContextBuilder/Internal.hs
@@ -335,14 +335,14 @@ deriving stock instance Show (ContextBuilder p n)
 
  When combining named 'ContextBuilder's, if both \'halves\' have a fragment
  associated to a specific name, the fragment in the /second/ argument will
- overwrite the first.
+ everything in /both/ fragments.
 
  @since 2.0
 -}
 instance Semigroup (ContextBuilder p n) where
   {-# INLINEABLE (<>) #-}
   NoNames cf <> NoNames cf' = NoNames $ cf <> cf'
-  WithNames cfs <> WithNames cfs' = WithNames $ cfs <> cfs'
+  WithNames cfs <> WithNames cfs' = WithNames . Map.unionWith (<>) cfs $ cfs'
 
 -- | @since 2.0
 instance Monoid (ContextBuilder p 'Anonymous) where

--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,15 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 9.0 -- 2022-03-10
+
+### Changed
+
+* Support for named and anonymous `ContextBuilder`s, in line with changes in
+  `plutus-context-builder`. These changes are technically breaking, but
+  shouldn't have issues in themselves, as long as the `ContextBuilder`s are
+  updated.
+
 ## 8.0 - 2022-02-08
 
 ### Changed

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
@@ -28,6 +28,7 @@ import Test.Tasty.Options (OptionSet, lookupOption)
 import Test.Plutus.ContextBuilder (
   ContextBuilder,
   InputPosition,
+  Naming,
   Purpose (ForMinting, ForSpending),
   TestUTXO (TestUTXO),
   TransactionConfig (TransactionConfig),
@@ -92,9 +93,9 @@ prepareConf getOpts env =
     ScriptInputPosition inputPosition' = lookupOption opts
 
 getScriptContext ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (p :: Purpose) (n :: Naming).
   (a -> TransactionConfig) ->
-  (a -> ContextBuilder p) ->
+  (a -> ContextBuilder p n) ->
   (a -> TestData p) ->
   a ->
   ScriptContext
@@ -104,7 +105,7 @@ getScriptContext getConf getCb getTd env = case getTd env of
   where
     conf :: TransactionConfig
     conf = getConf env
-    cb :: ContextBuilder p
+    cb :: ContextBuilder p n
     cb = getCb env
 
 getContext ::

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
@@ -19,7 +19,7 @@ import Plutus.V1.Ledger.Api (
   ScriptContext,
  )
 import Plutus.V1.Pretty (scriptContextToValue)
-import Test.Plutus.ContextBuilder (ContextBuilder, Purpose, TransactionConfig)
+import Test.Plutus.ContextBuilder (ContextBuilder, Naming, Purpose, TransactionConfig)
 import Test.Tasty.Plutus.Internal.Env (getScriptContext)
 import Test.Tasty.Plutus.Options (
   PlutusTracing (Always, OnlyOnFail),
@@ -133,9 +133,9 @@ didn'tLog getDumpedState env =
       $+$ getDumpedState env
 
 dumpState ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (p :: Purpose) (n :: Naming).
   (a -> TransactionConfig) ->
-  (a -> ContextBuilder p) ->
+  (a -> ContextBuilder p n) ->
   (a -> TestData p) ->
   [Text] ->
   a ->
@@ -165,9 +165,9 @@ dumpState getConf getCb getTd logs env =
           $+$ ppDoc v
 
 dumpState' ::
-  forall (a :: Type) (p :: Purpose).
+  forall (a :: Type) (p :: Purpose) (n :: Naming).
   (a -> TransactionConfig) ->
-  (a -> ContextBuilder p) ->
+  (a -> ContextBuilder p n) ->
   (a -> TestData p) ->
   [Text] ->
   a ->

--- a/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Script/Unit.hs
@@ -50,6 +50,7 @@ import Plutus.V1.Ledger.Scripts (
  )
 import Test.Plutus.ContextBuilder (
   ContextBuilder,
+  Naming,
   Purpose (ForMinting, ForSpending),
   TransactionConfig,
  )
@@ -120,14 +121,14 @@ import Type.Reflection (Typeable)
 {- | Specify that, given this test data and context, the validation should
  succeed.
 
- @since 3.0
+ @since 9.0
 -}
 shouldValidate ::
-  forall (p :: Purpose).
-  (Typeable p) =>
+  forall (p :: Purpose) (n :: Naming).
+  (Typeable p, Typeable n) =>
   String ->
   TestData p ->
-  ContextBuilder p ->
+  ContextBuilder p n ->
   WithScript p ()
 shouldValidate = addUnitTest Pass Nothing
 
@@ -137,28 +138,28 @@ shouldValidate = addUnitTest Pass Nothing
  * The validation should succeed; and
  * The trace that results should satisfy the predicate.
 
- @since 3.3
+ @since 9.0
 -}
 shouldValidateTracing ::
-  forall (p :: Purpose).
-  (Typeable p) =>
+  forall (p :: Purpose) (n :: Naming).
+  (Typeable p, Typeable n) =>
   String ->
   (Vector Text -> Bool) ->
   TestData p ->
-  ContextBuilder p ->
+  ContextBuilder p n ->
   WithScript p ()
 shouldValidateTracing name f = addUnitTest Pass (Just f) name
 
 {- | Specify that, given this test data and context, the validation should fail.
 
- @since 3.0
+ @since 9.0
 -}
 shouldn'tValidate ::
-  forall (p :: Purpose).
-  (Typeable p) =>
+  forall (p :: Purpose) (n :: Naming).
+  (Typeable p, Typeable n) =>
   String ->
   TestData p ->
-  ContextBuilder p ->
+  ContextBuilder p n ->
   WithScript p ()
 shouldn'tValidate = addUnitTest Fail Nothing
 
@@ -168,28 +169,28 @@ shouldn'tValidate = addUnitTest Fail Nothing
  * The validation should fail; and
  * The resulting trace should satisfy the predicate.
 
- @since 3.3
+ @since 9.0
 -}
 shouldn'tValidateTracing ::
-  forall (p :: Purpose).
-  (Typeable p) =>
+  forall (p :: Purpose) (n :: Naming).
+  (Typeable p, Typeable n) =>
   String ->
   (Vector Text -> Bool) ->
   TestData p ->
-  ContextBuilder p ->
+  ContextBuilder p n ->
   WithScript p ()
 shouldn'tValidateTracing name f = addUnitTest Fail (Just f) name
 
 -- Helpers
 
 addUnitTest ::
-  forall (p :: Purpose).
-  (Typeable p) =>
+  forall (p :: Purpose) (n :: Naming).
+  (Typeable p, Typeable n) =>
   Outcome ->
   Maybe (Vector Text -> Bool) ->
   String ->
   TestData p ->
-  ContextBuilder p ->
+  ContextBuilder p n ->
   WithScript p ()
 addUnitTest out trace name td cb = case td of
   SpendingTest {} -> WithSpending $ do
@@ -199,53 +200,53 @@ addUnitTest out trace name td cb = case td of
     tt <- asks (singleTest name . Minter out trace td cb)
     tell . Seq.singleton $ tt
 
-data ScriptTest (p :: Purpose) where
+data ScriptTest (p :: Purpose) (n :: Naming) where
   Spender ::
-    forall (d :: Type) (r :: Type).
+    forall (d :: Type) (r :: Type) (n :: Naming).
     Outcome ->
     Maybe (Vector Text -> Bool) ->
     TestData ( 'ForSpending d r) ->
-    ContextBuilder ( 'ForSpending d r) ->
+    ContextBuilder ( 'ForSpending d r) n ->
     TestScript ( 'ForSpending d r) ->
-    ScriptTest ( 'ForSpending d r)
+    ScriptTest ( 'ForSpending d r) n
   Minter ::
-    forall (r :: Type).
+    forall (r :: Type) (n :: Naming).
     Outcome ->
     Maybe (Vector Text -> Bool) ->
     TestData ( 'ForMinting r) ->
-    ContextBuilder ( 'ForMinting r) ->
+    ContextBuilder ( 'ForMinting r) n ->
     TestScript ( 'ForMinting r) ->
-    ScriptTest ( 'ForMinting r)
+    ScriptTest ( 'ForMinting r) n
 
-data UnitEnv (p :: Purpose) = UnitEnv
+data UnitEnv (p :: Purpose) (n :: Naming) = UnitEnv
   { envOpts :: OptionSet
-  , envScriptTest :: ScriptTest p
+  , envScriptTest :: ScriptTest p n
   }
 
 getShouldChat ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   PlutusTracing
 getShouldChat = lookupOption . envOpts
 
 getConf ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   TransactionConfig
 getConf = prepareConf envOpts
 
 getCB ::
-  forall (p :: Purpose).
-  UnitEnv p ->
-  ContextBuilder p
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
+  ContextBuilder p n
 getCB =
   envScriptTest >>> \case
     Spender _ _ _ cb _ -> cb
     Minter _ _ _ cb _ -> cb
 
 getTestData ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   TestData p
 getTestData =
   envScriptTest >>> \case
@@ -253,8 +254,8 @@ getTestData =
     Minter _ _ td _ _ -> td
 
 getScript ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   SomeScript p
 getScript =
   envScriptTest >>> \case
@@ -262,8 +263,8 @@ getScript =
     Minter _ _ _ _ mp -> SomeMinter . getTestMintingPolicy $ mp
 
 getMPred ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   Maybe (Vector Text -> Bool)
 getMPred =
   envScriptTest >>> \case
@@ -271,8 +272,8 @@ getMPred =
     Minter _ mPred _ _ _ -> mPred
 
 getExpected ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   Outcome
 getExpected =
   envScriptTest >>> \case
@@ -280,24 +281,24 @@ getExpected =
     Minter expected _ _ _ _ -> expected
 
 getSC ::
-  forall (p :: Purpose).
-  UnitEnv p ->
+  forall (p :: Purpose) (n :: Naming).
+  UnitEnv p n ->
   ScriptContext
 getSC = getScriptContext getConf getCB getTestData
 
 getDumpedState ::
-  forall (p :: Purpose).
+  forall (p :: Purpose) (n :: Naming).
   [Text] ->
-  UnitEnv p ->
+  UnitEnv p n ->
   Doc
 getDumpedState = dumpState getConf getCB getTestData
 
-instance (Typeable p) => IsTest (ScriptTest p) where
+instance (Typeable p, Typeable n) => IsTest (ScriptTest p n) where
   run opts vt _ = pure $ case result of
     Left err -> runReader (handleError err) env
     Right (logs, sr) -> runReader (deliverResult logs sr) env
     where
-      env :: UnitEnv p
+      env :: UnitEnv p n
       env =
         UnitEnv
           { envOpts = opts
@@ -317,9 +318,9 @@ instance (Typeable p) => IsTest (ScriptTest p) where
       ]
 
 handleError ::
-  forall (p :: Purpose).
+  forall (p :: Purpose) (n :: Naming).
   ScriptError ->
-  Reader (UnitEnv p) Result
+  Reader (UnitEnv p n) Result
 handleError = \case
   EvaluationError logs msg ->
     asks getExpected >>= \case
@@ -329,10 +330,10 @@ handleError = \case
   MalformedScript msg -> pure . testFailed $ malformedScript msg
 
 deliverResult ::
-  forall (p :: Purpose).
+  forall (p :: Purpose) (n :: Naming).
   [Text] ->
   ScriptResult ->
-  Reader (UnitEnv p) Result
+  Reader (UnitEnv p n) Result
 deliverResult logs result = do
   expected <- asks getExpected
   case (expected, result) of
@@ -344,10 +345,14 @@ deliverResult logs result = do
     (_, InternalError t) -> asks (testFailed . internalError state t)
     (_, ParseFailed t) -> asks (testFailed . noParse state t)
   where
-    state :: UnitEnv p -> Doc
+    state :: UnitEnv p n -> Doc
     state = getDumpedState logs
 
-tryPass :: Maybe (Vector Text -> Bool) -> [Text] -> Reader (UnitEnv p) Result
+tryPass ::
+  forall (p :: Purpose) (n :: Naming).
+  Maybe (Vector Text -> Bool) ->
+  [Text] ->
+  Reader (UnitEnv p n) Result
 tryPass mPred logs = case mPred of
   Nothing -> asks (testPassed . doPass getShouldChat logs)
   Just f ->

--- a/tasty-plutus/src/Test/Tasty/Plutus/TestData.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/TestData.hs
@@ -38,6 +38,7 @@ import Test.Plutus.ContextBuilder (
   ContextBuilder,
   MintingPolicyAction (BurnAction, MintAction),
   MintingPolicyTask (MPTask),
+  Naming,
   Purpose (ForMinting, ForSpending),
   Tokens (Tokens),
   burnTokens,
@@ -150,41 +151,42 @@ static x = Methodology (pure x) (const [])
 {- | Contains a means of generating a seed and a function
  for creating 'TestItems' from the seed.
 
- @since 5.0
+ @since 9.0
 -}
-data Generator (a :: Type) (p :: Purpose) where
-  -- | @since 5.0
+data Generator (a :: Type) (p :: Purpose) (n :: Naming) where
+  -- | @since 9.0
   GenForSpending ::
-    forall (a :: Type) (d :: Type) (r :: Type).
+    forall (a :: Type) (d :: Type) (r :: Type) (n :: Naming).
     (Show a) =>
     -- | 'Methodology' for seed
     -- @since 5.0
     Methodology a ->
     -- | Function for producing 'TestItems' from the seed
-    -- @since 5.0
-    (a -> TestItems ( 'ForSpending d r)) ->
-    Generator a ( 'ForSpending d r)
+    -- @since 9.0
+    (a -> TestItems ( 'ForSpending d r) n) ->
+    Generator a ( 'ForSpending d r) n
+  -- | @since 9.0
   GenForMinting ::
-    forall (a :: Type) (r :: Type).
+    forall (a :: Type) (r :: Type) (n :: Naming).
     (Show a) =>
     -- | 'Methodology' for seed
     -- @since 5.0
     Methodology a ->
     -- | Function for producing 'TestItems' from the seed
-    -- @since 5.0
-    (a -> TestItems ( 'ForMinting r)) ->
-    Generator a ( 'ForMinting r)
+    -- @since 9.0
+    (a -> TestItems ( 'ForMinting r) n) ->
+    Generator a ( 'ForMinting r) n
 
 {- | Сontains the necessary data set for script checking.
  This dataset does not cover any set of tests or conditions.
  It is used only to check the result of calling the script with certain values.
 
- @since 5.0
+ @since 9.0
 -}
-data TestItems (p :: Purpose) where
-  -- | @since 5.0
+data TestItems (p :: Purpose) (n :: Naming) where
+  -- | @since 9.0
   ItemsForSpending ::
-    forall (datum :: Type) (redeemer :: Type).
+    forall (datum :: Type) (redeemer :: Type) (n :: Naming).
     ( ToData datum
     , ToData redeemer
     , FromData datum
@@ -202,16 +204,16 @@ data TestItems (p :: Purpose) where
       -- @since 5.0
       spendValue :: Value
     , -- | ContextBuilder used for creating ScriptContext
-      -- @since 5.0
-      spendCB :: ContextBuilder ( 'ForSpending datum redeemer)
+      -- @since 9.0
+      spendCB :: ContextBuilder ( 'ForSpending datum redeemer) n
     , -- | Result expected from calling the Validator
       -- | @since 5.0
       spendOutcome :: Outcome
     } ->
-    TestItems ( 'ForSpending datum redeemer)
-  -- | @since 5.0
+    TestItems ( 'ForSpending datum redeemer) n
+  -- | @since 9.0
   ItemsForMinting ::
-    forall (redeemer :: Type).
+    forall (redeemer :: Type) (n :: Naming).
     ( ToData redeemer
     , FromData redeemer
     , Show redeemer
@@ -223,13 +225,13 @@ data TestItems (p :: Purpose) where
       -- @since 6.0
       mpTasks :: NonEmpty MintingPolicyTask
     , -- | ContextBuilder used for creating ScriptContext
-      -- @since 5.0
-      mpCB :: ContextBuilder ( 'ForMinting redeemer)
+      -- @since 9.0
+      mpCB :: ContextBuilder ( 'ForMinting redeemer) n
     , -- | Result expected from calling the MintingPolicy
       -- | @since 5.0
       mpOutcome :: Outcome
     } ->
-    TestItems ( 'ForMinting redeemer)
+    TestItems ( 'ForMinting redeemer) n
 
--- | @since 6.0
-deriving stock instance Show (TestItems p)
+-- | @since 9.0
+deriving stock instance Show (TestItems p n)

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -70,7 +70,7 @@ library
     , containers              ^>=0.6.2.1
     , filepath                ^>=1.4.2
     , mtl                     ^>=2.2.2
-    , plutus-context-builder  ^>=1.0
+    , plutus-context-builder  ^>=2.0
     , plutus-core
     , plutus-ledger
     , plutus-ledger-api
@@ -102,7 +102,7 @@ test-suite properties
   hs-source-dirs: test/Properties
   build-depends:
     , base                         ^>=4.14
-    , plutus-context-builder       ^>=1.0
+    , plutus-context-builder
     , plutus-contract
     , plutus-ledger
     , plutus-ledger-api

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               tasty-plutus
-version:            8.0
+version:            9.0
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -110,7 +110,7 @@ test-suite properties
     , plutus-tx-plugin
     , quickcheck-plutus-instances  ^>=2.2
     , tasty                        ^>=1.4.1
-    , tasty-plutus                 ^>=8.0
+    , tasty-plutus
     , tasty-quickcheck             ^>=0.10.1.2
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N -O1

--- a/tasty-plutus/test/Properties/MintingPolicy.hs
+++ b/tasty-plutus/test/Properties/MintingPolicy.hs
@@ -12,6 +12,7 @@ import Prelude hiding (($), (&&), (*), (+), (==))
 import Ledger.Crypto (PubKeyHash)
 import Test.Plutus.ContextBuilder (
   ContextBuilder,
+  Naming (Anonymous),
   Purpose (ForMinting),
   inTokensFromPubKey,
   outTokensToPubKey,
@@ -83,7 +84,7 @@ gen1 = Methodology gen' genericShrink
 -- | Creates TestItems with an arbitrary key used in Redeemer
 transform1 ::
   (Integer, Tokens, Tokens) ->
-  TestItems ( 'ForMinting Integer)
+  TestItems ( 'ForMinting Integer) 'Anonymous
 transform1 (key, toksMint, toksBurn) =
   ItemsForMinting
     { mpRedeemer = key
@@ -98,21 +99,21 @@ transform1 (key, toksMint, toksBurn) =
         <> burnTokens toksBurn
     out :: Outcome
     out = passIf $ key == secretKey
-    cb :: ContextBuilder ( 'ForMinting Integer)
+    cb :: ContextBuilder ( 'ForMinting Integer) 'Anonymous
     cb =
-      outTokensToPubKey "toUser" userPKHash1 toksMint
-        <> inTokensFromPubKey "fromUser" userPKHash2 toksBurn
-        <> signedWith "userSignature" userPKHash2
+      outTokensToPubKey userPKHash1 toksMint
+        <> inTokensFromPubKey userPKHash2 toksBurn
+        <> signedWith userPKHash2
 
 -- | Creates TestItems with correct secretKey used in Redeemer
 transform2 ::
   (Integer, Tokens, Tokens) ->
-  TestItems ( 'ForMinting Integer)
+  TestItems ( 'ForMinting Integer) 'Anonymous
 transform2 = transformItems . transform1
   where
     transformItems ::
-      TestItems ( 'ForMinting Integer) ->
-      TestItems ( 'ForMinting Integer)
+      TestItems ( 'ForMinting Integer) 'Anonymous ->
+      TestItems ( 'ForMinting Integer) 'Anonymous
     transformItems = \case
       ItemsForMinting _ t c o -> ItemsForMinting secretKey t c o
 

--- a/tasty-plutus/test/Properties/Validator.hs
+++ b/tasty-plutus/test/Properties/Validator.hs
@@ -12,6 +12,7 @@ import Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Value (Value)
 import Test.Plutus.ContextBuilder (
   ContextBuilder,
+  Naming (Anonymous),
   Purpose (ForSpending),
   outToPubKey,
  )
@@ -90,7 +91,7 @@ genForSimple = Methodology gen' genericShrink
 -- | Creates TestItems with an arbitrary sum used in Redeemer
 transformForSimple1 ::
   (Integer, Integer, Integer, Integer, Value) ->
-  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer))
+  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
 transformForSimple1 (i1, i2, iSum, _, val) =
   ItemsForSpending
     { spendDatum = (i1, i2)
@@ -100,15 +101,15 @@ transformForSimple1 (i1, i2, iSum, _, val) =
     , spendOutcome = out
     }
   where
-    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer))
-    cb = outToPubKey "outToUser" userPKHash val
+    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
+    cb = outToPubKey userPKHash val
     out :: Outcome
     out = if iSum == i1 + i2 then Pass else Fail
 
 -- | Creates TestItems with an arbitrary product used in Redeemer
 transformForSimple2 ::
   (Integer, Integer, Integer, Integer, Value) ->
-  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer))
+  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
 transformForSimple2 (i1, i2, _, iProd, val) =
   ItemsForSpending
     { spendDatum = (i1, i2)
@@ -118,15 +119,15 @@ transformForSimple2 (i1, i2, _, iProd, val) =
     , spendOutcome = out
     }
   where
-    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer))
-    cb = outToPubKey "outToUser" userPKHash val
+    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
+    cb = outToPubKey userPKHash val
     out :: Outcome
     out = passIf $ iProd == i1 * i2
 
 -- | Always creates TestItems with correct sum and product
 transformForSimple3 ::
   (Integer, Integer, Integer, Integer, Value) ->
-  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer))
+  TestItems ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
 transformForSimple3 (i1, i2, _, _, val) =
   ItemsForSpending
     { spendDatum = (i1, i2)
@@ -136,8 +137,8 @@ transformForSimple3 (i1, i2, _, _, val) =
     , spendOutcome = out
     }
   where
-    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer))
-    cb = outToPubKey "outToUser" userPKHash val
+    cb :: ContextBuilder ( 'ForSpending (Integer, Integer) (Integer, Integer)) 'Anonymous
+    cb = outToPubKey userPKHash val
     out :: Outcome
     out = Pass
 
@@ -181,7 +182,7 @@ genForParam = Methodology gen genericShrink
 -- | Creates TestItems with an arbitrary sum used in Redeemer
 transformForParam ::
   (Integer, Integer, Value) ->
-  TestItems ( 'ForSpending () Integer)
+  TestItems ( 'ForSpending () Integer) 'Anonymous
 transformForParam (secret, guess, val) =
   ItemsForSpending
     { spendDatum = ()
@@ -191,8 +192,8 @@ transformForParam (secret, guess, val) =
     , spendOutcome = out
     }
   where
-    cb :: ContextBuilder ( 'ForSpending () Integer)
-    cb = outToPubKey "outToUser" userPKHash val
+    cb :: ContextBuilder ( 'ForSpending () Integer) 'Anonymous
+    cb = outToPubKey userPKHash val
     out :: Outcome
     out = if secret == guess then Pass else Fail
 


### PR DESCRIPTION
This aims to address #193, while causing a minimal amount of disruption. Unfortunately, this will require `tasty-plutus` to be bumped as well (due to all the signatures changing), but this shouldn't affect existing code built atop it as long as the `ContextBuilder`s are changed appropriately.

@blamario - thoughts?