### PR TITLE
Simple estimator for scripts being tested

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,7 +4,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
-## 8.1 - 2022-03-14
+## 8.1 - 2022-03-16
 
 ### Added
 

--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,13 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 8.1 - 2022-03-14
+
+### Added
+
+* `PlutusEstimate` option, which displays estimated memory and CPU use for
+  scripts instead of testing them.
+
 ## 8.0 - 2022-02-08
 
 ### Changed

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Estimate.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Estimate.hs
@@ -1,0 +1,61 @@
+module Test.Tasty.Plutus.Internal.Estimate (
+  spenderEstimate,
+  minterEstimate,
+) where
+
+import Data.Bifunctor (second)
+import Data.Kind (Type)
+import Plutus.V1.Ledger.Api (ExBudget, toBuiltinData)
+import Plutus.V1.Ledger.Scripts (
+  Context (Context),
+  Datum (Datum),
+  Redeemer (Redeemer),
+  ScriptError,
+  runMintingPolicyScript,
+  runScript,
+ )
+import Test.Plutus.ContextBuilder (
+  Purpose (ForMinting, ForSpending),
+  TestUTXO (TestUTXO),
+  mintingScriptContext,
+  spendingScriptContext,
+ )
+import Test.Tasty.Options (OptionSet)
+import Test.Tasty.Plutus.Internal.Env (prepareConf)
+import Test.Tasty.Plutus.Internal.TestScript (
+  TestScript (TestMintingPolicy, TestValidator),
+ )
+import Test.Tasty.Plutus.TestData (
+  TestItems (ItemsForMinting, ItemsForSpending),
+ )
+
+spenderEstimate ::
+  forall (d :: Type) (r :: Type).
+  OptionSet ->
+  TestScript ( 'ForSpending d r) ->
+  TestItems ( 'ForSpending d r) ->
+  Either ScriptError ExBudget
+spenderEstimate opts ts ti = case ti of
+  ItemsForSpending dat red v cb _ -> case ts of
+    TestValidator _ val ->
+      let conf = prepareConf id opts
+          context = spendingScriptContext conf cb (TestUTXO dat v)
+          dat' = Datum . toBuiltinData $ dat
+          red' = Redeemer . toBuiltinData $ red
+          context' = Context . toBuiltinData $ context
+       in second fst . runScript context' val dat' $ red'
+
+minterEstimate ::
+  forall (r :: Type).
+  OptionSet ->
+  TestScript ( 'ForMinting r) ->
+  TestItems ( 'ForMinting r) ->
+  Either ScriptError ExBudget
+minterEstimate opts ts ti = case ti of
+  ItemsForMinting red tasks cb _ -> case ts of
+    TestMintingPolicy _ mp ->
+      let conf = prepareConf id opts
+          context = mintingScriptContext conf cb tasks
+          red' = Redeemer . toBuiltinData $ red
+          context' = Context . toBuiltinData $ context
+       in second fst . runMintingPolicyScript context' mp $ red'

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
@@ -13,6 +13,8 @@ module Test.Tasty.Plutus.Internal.Feedback (
   ourStyle,
   errorNoEstimate,
   reportBudgets,
+  explainFailureEstimation,
+  explainFailureExhaustion,
 ) where
 
 import Data.Kind (Type)
@@ -50,6 +52,27 @@ import Prelude hiding ((<>))
 
 ourStyle :: Style
 ourStyle = style {lineLength = 80}
+
+explainFailureExhaustion :: String
+explainFailureExhaustion =
+  renderStyle ourStyle $
+    "Gave up trying to generate a successful run for estimation."
+      $+$ "This can happen due to what \'failure\' means for a script in tasty-plutus:"
+      $+$ hang " * " 4 "The script ran successfully, but didn't log a success from its wrapper; or"
+      $+$ hang " * " 4 "The script crashed or failed to evaluate."
+      $+$ "Because of how the CEK evaluator for scripts works, we can only establish an estimate for the first case."
+      $+$ "As property tests generate inputs pseudorandomly, even tests where failure is not guaranteed, if success isn't likely enough, we might never see an instrumentable case."
+      $+$ "If you are seeing this message, this is exactly what happened."
+
+explainFailureEstimation :: String
+explainFailureEstimation =
+  renderStyle ourStyle $
+    "Cannot provide estimates for test cases whose scripts are designed to fail."
+      $+$ "The reason for this relates to what \'failure\' can mean for a script in tasty-plutus:"
+      $+$ hang " * " 4 "The script ran successfully, but didn't log a success from its wrapper; or"
+      $+$ hang " * " 4 "The script crashed or failed to evaluate."
+      $+$ "Because of how the CEK evaluator for scripts works, we can only establish an estimate for the first case."
+      $+$ "Since we can't tell these cases apart in general, we provide no estimates in this situation."
 
 reportBudgets :: Integer -> Integer -> String
 reportBudgets bCPU bMem =
@@ -102,8 +125,8 @@ errorNoEstimate :: [Text] -> String -> String
 errorNoEstimate logs msg =
   renderStyle ourStyle $
     "Could not provide estimate due to script error"
-      $+$ hang "Description" 4 (text msg)
-      $+$ hang "Logs" 4 (dumpLogs logs)
+      $+$ hang "Description:" 4 (text msg)
+      $+$ hang "Logs:" 4 (dumpLogs logs)
 
 noOutcome ::
   forall (a :: Type).

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
@@ -57,22 +57,13 @@ explainFailureExhaustion :: String
 explainFailureExhaustion =
   renderStyle ourStyle $
     "Gave up trying to generate a successful run for estimation."
-      $+$ "This can happen due to what \'failure\' means for a script in tasty-plutus:"
-      $+$ hang " * " 4 "The script ran successfully, but didn't log a success from its wrapper; or"
-      $+$ hang " * " 4 "The script crashed or failed to evaluate."
-      $+$ "Because of how the CEK evaluator for scripts works, we can only establish an estimate for the first case."
-      $+$ "As property tests generate inputs pseudorandomly, even tests where failure is not guaranteed, if success isn't likely enough, we might never see an instrumentable case."
-      $+$ "If you are seeing this message, this is exactly what happened."
+      $+$ "See documentation for PlutusEstimate for an explanation."
 
 explainFailureEstimation :: String
 explainFailureEstimation =
   renderStyle ourStyle $
     "Cannot provide estimates for test cases whose scripts are designed to fail."
-      $+$ "The reason for this relates to what \'failure\' can mean for a script in tasty-plutus:"
-      $+$ hang " * " 4 "The script ran successfully, but didn't log a success from its wrapper; or"
-      $+$ hang " * " 4 "The script crashed or failed to evaluate."
-      $+$ "Because of how the CEK evaluator for scripts works, we can only establish an estimate for the first case."
-      $+$ "Since we can't tell these cases apart in general, we provide no estimates in this situation."
+      $+$ "See documentation for PlutusEstimate for an explanation."
 
 reportBudgets :: Integer -> Integer -> String
 reportBudgets bCPU bMem =

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Feedback.hs
@@ -11,6 +11,8 @@ module Test.Tasty.Plutus.Internal.Feedback (
   dumpState,
   dumpState',
   ourStyle,
+  errorNoEstimate,
+  reportBudgets,
 ) where
 
 import Data.Kind (Type)
@@ -31,6 +33,7 @@ import Text.PrettyPrint (
   colon,
   hang,
   int,
+  integer,
   renderStyle,
   style,
   text,
@@ -44,6 +47,13 @@ import Prelude hiding ((<>))
 
 ourStyle :: Style
 ourStyle = style {lineLength = 80}
+
+reportBudgets :: Integer -> Integer -> String
+reportBudgets bCPU bMem =
+  renderStyle ourStyle $
+    "Resource estimates:"
+      $+$ hang "CPU" 4 (integer bCPU <+> "picoseconds")
+      $+$ hang "Memory" 4 (integer bMem <+> "machine words")
 
 unexpectedFailure ::
   forall (a :: Type).
@@ -67,6 +77,13 @@ malformedScript msg =
   renderStyle ourStyle $
     "Script was malformed"
       $+$ hang "Details" 4 (text msg)
+
+errorNoEstimate :: [Text] -> String -> String
+errorNoEstimate logs msg =
+  renderStyle ourStyle $
+    "Could not provide estimate due to script error"
+      $+$ hang "Description" 4 (text msg)
+      $+$ hang "Logs" 4 (dumpLogs logs)
 
 noOutcome ::
   forall (a :: Type).

--- a/tasty-plutus/src/Test/Tasty/Plutus/Options.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Options.hs
@@ -20,6 +20,7 @@ module Test.Tasty.Plutus.Options (
   TestValidatorHash (..),
   PlutusTracing (..),
   ScriptInputPosition (..),
+  PlutusEstimate (..),
 
   -- * Property test options
   PropertyTestCount,
@@ -197,6 +198,30 @@ instance IsOption PlutusTracing where
   optionHelp = Tagged "Always provide Plutus traces for unit tests."
   showDefaultValue = const . Just $ "Only on failure"
   optionCLParser = mkFlagCLParser mempty Always
+
+{- | Whether we should run the tests, or only present estimates of the scripts.
+
+ The default value is 'NoEstimates'. The option is controlled purely by a
+ flag; if you want to use it, pass @--estimate-only@.
+
+ @since 8.1
+-}
+data PlutusEstimate = NoEstimates | EstimateOnly
+  deriving stock
+    ( -- | @since 8.1
+      Eq
+    , -- | @since 8.1
+      Show
+    )
+
+-- | @since 8.1
+instance IsOption PlutusEstimate where
+  defaultValue = NoEstimates
+  parseValue = const (Just EstimateOnly)
+  optionName = Tagged "estimate-only"
+  optionHelp = Tagged "Don't run tests; only show estimates of resource use."
+  showDefaultValue = const . Just $ "Run tests, don't estimate"
+  optionCLParser = mkFlagCLParser mempty EstimateOnly
 
 {- | Where to place the script input in 'txInfoInputs' when generating a
  'ScriptContext'.

--- a/tasty-plutus/src/Test/Tasty/Plutus/Options.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Options.hs
@@ -2,7 +2,7 @@
 
 {- |
  Module: Test.Tasty.Plutus.Options
- Copyright: (C) MLabs 2021
+ Copyright: (C) MLabs 2021-2022
  License: Apache 2.0
  Maintainer: Koz Ross <koz@mlabs.city>
  Portability: GHC only
@@ -203,6 +203,11 @@ instance IsOption PlutusTracing where
 
  The default value is 'NoEstimates'. The option is controlled purely by a
  flag; if you want to use it, pass @--estimate-only@.
+
+ = Note
+
+ This does not affect size tests, as there's no general way to run the code
+ they are passed.
 
  @since 8.1
 -}

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               tasty-plutus
-version:            8.0
+version:            8.1
 extra-source-files: CHANGELOG.md
 
 common lang
@@ -110,7 +110,7 @@ test-suite properties
     , plutus-tx-plugin
     , quickcheck-plutus-instances  ^>=2.2
     , tasty                        ^>=1.4.1
-    , tasty-plutus                 ^>=8.0
+    , tasty-plutus
     , tasty-quickcheck             ^>=0.10.1.2
 
   ghc-options:    -threaded -rtsopts -with-rtsopts=-N -O1

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -56,6 +56,7 @@ library
   other-modules:
     Test.Tasty.Plutus.Internal.DumpScript
     Test.Tasty.Plutus.Internal.Env
+    Test.Tasty.Plutus.Internal.Estimate
     Test.Tasty.Plutus.Internal.Feedback
     Test.Tasty.Plutus.Internal.Options
     Test.Tasty.Plutus.Internal.Run


### PR DESCRIPTION
This provides `tasty-plutus` an additional option, allowing a rough estimate of how much time and space a script execution under test will take. This is not a full-blown benchmarking solution, as it's fairly inexact, but it can be used to give a back-of-envelope estimate.

Closes #194 . Seem OK by you @maciej-bendkowski, @samuelWilliams99?