### PR TITLE
Add support for untyped scripts in `tasty-plutus`

### DIFF
--- a/tasty-plutus/CHANGELOG.md
+++ b/tasty-plutus/CHANGELOG.md
@@ -4,6 +4,13 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 
 ## Unreleased
 
+## 8.1 - 2022-03-20
+
+### Added
+
+* `mkTestValidatorUntyped` and `mkTestMintingPolicyUntyped` for constructing
+  `TestScript`s out of untyped code
+
 ## 8.0 - 2022-02-08
 
 ### Changed
@@ -11,7 +18,7 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 * `ContextBuilder` with all related types and constructors moved to separate
   `plutus-context-builder` library. At the same time, the internal structure
   of the `ContextBuilder` has changed, as well as the basic building blocks.
-  
+
 ## 7.3 - 2022-02-07
 
 ### Changed
@@ -42,8 +49,8 @@ This format is based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0).
 ## 7.0 -- 2022-01-21
 
 ### Changed
-  
-* Plutus upgrade: `plutus` pinned to `65bad0fd53e432974c3c203b1b1999161b6c2dce`, 
+
+* Plutus upgrade: `plutus` pinned to `65bad0fd53e432974c3c203b1b1999161b6c2dce`,
   `plutus-apps` pinned to `34fe6eeff441166fee0cd0ceba68c1439f0e93d2`
 
 ## 6.0 -- 2022-01-19

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Env.hs
@@ -22,7 +22,7 @@ import Plutus.V1.Ledger.Api (
   ValidatorHash,
   Value,
  )
-import Plutus.V1.Ledger.Scripts (Context (Context), ScriptError)
+import Plutus.V1.Ledger.Scripts (Context (Context))
 import Test.Tasty.Options (OptionSet, lookupOption)
 
 import Test.Plutus.ContextBuilder (
@@ -120,7 +120,7 @@ getScriptResult ::
   (a -> TestData p) ->
   (a -> Context) ->
   a ->
-  Either ScriptError ([Text], ScriptResult)
+  Either ScriptResult [Text]
 getScriptResult getScript getTd getCtx env =
   case (getScript env, getTd env) of
     (SomeSpender val, SpendingTest d r _) ->

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/Run.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/Run.hs
@@ -14,19 +14,18 @@ import Plutus.V1.Ledger.Api (
  )
 import Plutus.V1.Ledger.Scripts (
   Context,
-  ScriptError,
+  ScriptError (EvaluationError, EvaluationException, MalformedScript),
   runMintingPolicyScript,
   runScript,
  )
 import Safe (lastMay)
 
--- The result of parsing a log from a script emulation
+-- The result of parsing a log from a errored script emulation
 data ScriptResult
-  = ScriptPassed
-  | ScriptFailed
-  | NoOutcome
-  | ParseFailed Text
-  | InternalError Text
+  = ScriptFailed [Text] String
+  | ParseFailed [Text] Text
+  | PlutusEvaluationException String String
+  | PlutusMalformedScript String
   deriving stock (Eq, Show)
 
 testValidatorScript ::
@@ -34,25 +33,25 @@ testValidatorScript ::
   Validator ->
   Datum ->
   Redeemer ->
-  Either ScriptError ([Text], ScriptResult)
+  Either ScriptResult [Text]
 testValidatorScript ctx val d r = case runScript ctx val d r of
-  Left err -> Left err
-  Right (_, logs) -> Right . (logs,) . parseLogs $ logs
+  Left err -> Left $ parseError err
+  Right (_, logs) -> Right logs
 
 testMintingPolicyScript ::
   Context ->
   MintingPolicy ->
   Redeemer ->
-  Either ScriptError ([Text], ScriptResult)
+  Either ScriptResult [Text]
 testMintingPolicyScript ctx mp r = case runMintingPolicyScript ctx mp r of
-  Left err -> Left err
-  Right (_, logs) -> Right . (logs,) . parseLogs $ logs
+  Left err -> Left $ parseError err
+  Right (_, logs) -> Right logs
 
-parseLogs :: [Text] -> ScriptResult
-parseLogs logs = case lastMay logs >>= Text.stripPrefix "tasty-plutus: " of
-  Nothing -> NoOutcome
-  Just "Pass" -> ScriptPassed
-  Just "Fail" -> ScriptFailed
-  Just t -> case Text.stripPrefix "Parse failed: " t of
-    Nothing -> InternalError t
-    Just t' -> ParseFailed t'
+parseError :: ScriptError -> ScriptResult
+parseError = \case
+  EvaluationError logs msg ->
+    case lastMay logs >>= Text.stripPrefix "tasty-plutus: Parse failed: " of
+      Nothing -> ScriptFailed logs msg
+      Just t -> ParseFailed logs t
+  EvaluationException name msg -> PlutusEvaluationException name msg
+  MalformedScript msg -> PlutusMalformedScript msg

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/TestScript.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/TestScript.hs
@@ -43,15 +43,15 @@ import Test.Plutus.ContextBuilder (Purpose (ForMinting, ForSpending))
 data TestScript (p :: Purpose) where
   -- | since 6.0
   TestValidator ::
-    forall (d :: Type) (r :: Type) (datum :: Type) (redeemer :: Type) (ctx :: Type).
-    { getTestValidatorCode :: CompiledCode (datum -> redeemer -> ctx -> Bool)
+    forall (d :: Type) (r :: Type) (code :: Type).
+    { getTestValidatorCode :: CompiledCode code
     , getTestValidator :: Validator
     } ->
     TestScript ( 'ForSpending d r)
   -- | since 6.0
   TestMintingPolicy ::
-    forall (r :: Type) (redeemer :: Type) (ctx :: Type).
-    { getTestMintingPolicyCode :: CompiledCode (redeemer -> ctx -> Bool)
+    forall (r :: Type) (code :: Type).
+    { getTestMintingPolicyCode :: CompiledCode code
     , getTestMintingPolicy :: MintingPolicy
     } ->
     TestScript ( 'ForMinting r)
@@ -142,6 +142,33 @@ mkTestValidatorUnsafe v wr =
       applyCode $$(compile [||getWrappedValidator||]) $
         wr `applyCode` v
 
+{- | Like 'mkTestValidator', but accepts an untyped validator. You need to
+ manually annotate the return type and make sure they correspond correctly
+ to the 'BuiltinData's handled by the validator.
+
+ = Note
+
+ This is not safe and may result in an error when the script is run.
+
+ = Usage
+
+ > myValidator :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+ > myValidator d r ctx = ...
+
+ > testValidator ::
+ >     TestScript ( 'ForSpending SomeDatumType SomeRedeemerType)
+ > testValidator =
+ >  mkTestValidatorUntyped $$(compile [||myValidator||])
+
+ @since 8.1
+-}
+mkTestValidatorUntyped ::
+  forall (d :: Type) (r :: Type).
+  CompiledCode (BuiltinData -> BuiltinData -> BuiltinData -> ()) ->
+  TestScript ( 'ForSpending d r)
+mkTestValidatorUntyped vl =
+  TestValidator vl $ mkValidatorScript vl
+
 {- | Create a 'TestScript' with the given 'MintingPolicy', parameterized
  with proper redeemer type.
 
@@ -197,6 +224,33 @@ mkTestMintingPolicyUnsafe mp wr =
     mkMintingPolicyScript $
       applyCode $$(compile [||getWrappedMintingPolicy||]) $
         wr `applyCode` mp
+
+{- | Like 'mkTestMintingPolicy', but accepts an untyped one. You need to
+ manually annotate the return type and make sure they correspond correctly
+ to the 'BuiltinData's handled by the minting policy.
+
+ = Note
+
+ This is not safe and may result in an error when the script is run.
+
+ = Usage
+
+ > myMintingPolicy :: BuiltinData -> BuiltinData -> ()
+ > myMintingPolicy r ctx = ...
+
+ > testMintingPolicy ::
+ >     TestScript ( 'ForMinting SomeRedeemerType)
+ > testMintingPolicy =
+ >  mkTestMintingPolicyUntyped $$(compile [||myMintingPolicy||])
+
+ @since 8.1
+-}
+mkTestMintingPolicyUntyped ::
+  forall (r :: Type).
+  CompiledCode (BuiltinData -> BuiltinData -> ()) ->
+  TestScript ( 'ForMinting r)
+mkTestMintingPolicyUntyped mp =
+  TestMintingPolicy mp $ mkMintingPolicyScript mp
 
 {- | A wrapper for validators. Use this to construct @TestScript ForSpending@.
 

--- a/tasty-plutus/src/Test/Tasty/Plutus/Internal/TestScript.hs
+++ b/tasty-plutus/src/Test/Tasty/Plutus/Internal/TestScript.hs
@@ -23,9 +23,10 @@ import Plutus.V1.Ledger.Api (
   mkValidatorScript,
  )
 import PlutusTx (CompiledCode, applyCode)
-import PlutusTx.Builtins (BuiltinData, BuiltinString, appendString, trace)
+import PlutusTx.Builtins (BuiltinData, BuiltinString, appendString)
 import PlutusTx.IsData.Class (FromData (fromBuiltinData))
 import PlutusTx.TH (compile)
+import PlutusTx.Trace (traceError)
 import Test.Plutus.ContextBuilder (Purpose (ForMinting, ForSpending))
 
 {- | Typed wrapper for the 'Validator' and 'MintingPolicy' used to match
@@ -280,16 +281,13 @@ toTestMintingPolicy f = WrappedMintingPolicy $ \r p ->
 
 {-# INLINEABLE reportParseFailed #-}
 reportParseFailed :: BuiltinString -> ()
-reportParseFailed what = report ("Parse failed: " `appendString` what)
+reportParseFailed what =
+  traceError ("tasty-plutus: Parse failed: " `appendString` what)
 
 {-# INLINEABLE reportPass #-}
 reportPass :: ()
-reportPass = report "Pass"
+reportPass = ()
 
 {-# INLINEABLE reportFail #-}
 reportFail :: ()
-reportFail = report "Fail"
-
-{-# INLINEABLE report #-}
-report :: BuiltinString -> ()
-report what = trace ("tasty-plutus: " `appendString` what) ()
+reportFail = traceError "tasty-plutus: Fail"

--- a/tasty-plutus/tasty-plutus.cabal
+++ b/tasty-plutus/tasty-plutus.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               tasty-plutus
-version:            8.0
+version:            8.1
 extra-source-files: CHANGELOG.md
 
 common lang


### PR DESCRIPTION
Fixes #198.

- Allows the construction of `TestScript`s from untyped validators
- Internally, uses `error` to signal script failure (including returning `False`)

@blamario Does this look good to you?